### PR TITLE
Fixes/ai result fix posthog ml tracking

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/sync/AppSyncWorker.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/sync/AppSyncWorker.kt
@@ -159,7 +159,7 @@ constructor(
 
         val docReferences = openSrpFhirEngine.search<DocumentReference> {}.filter {
             it.resource.description != DocumentReferenceCaseType.DRAFT
-        }.shuffled()
+        }.sortedByDescending { it.resource.date }
         val totalDocuments = docReferences.size
         var pendingDocuments = totalDocuments
         var atLeastOneSuccess = false

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/sync/AppSyncWorker.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/sync/AppSyncWorker.kt
@@ -42,6 +42,7 @@ import com.google.android.fhir.sync.upload.UploadStrategy
 import com.google.gson.Gson
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okhttp3.MediaType.Companion.toMediaType
@@ -65,6 +66,8 @@ import org.smartregister.fhircore.engine.domain.networkUtils.WorkerConstants.DOC
 import org.smartregister.fhircore.engine.domain.networkUtils.WorkerConstants.DOC_STATUS
 import org.smartregister.fhircore.engine.domain.networkUtils.WorkerConstants.REPLACE
 import org.smartregister.fhircore.engine.util.SecureSharedPreference
+import org.smartregister.fhircore.engine.util.analytics.AnalyticsLogger
+import org.smartregister.fhircore.engine.util.analytics.AnalyticsLoggerEntryPoint
 import org.smartregister.fhircore.engine.util.extension.logicalId
 import org.smartregister.fhircore.engine.util.notificationHelper.CHANNEL_ID
 import org.smartregister.fhircore.engine.util.notificationHelper.NOTIFICATION_ID
@@ -86,6 +89,12 @@ constructor(
     val secureSharedPreference: SecureSharedPreference,
     private val gson: Gson
 ) : FhirSyncWorker(appContext, workerParams) {
+    private val analyticsLogger: AnalyticsLogger by lazy {
+        EntryPointAccessors.fromApplication(
+            applicationContext,
+            AnalyticsLoggerEntryPoint::class.java,
+        ).analyticsLogger()
+    }
 
     companion object {
         val mutex = Mutex()
@@ -193,7 +202,14 @@ constructor(
                 uploadImageMutex.withLock {
                     Timber.i("Processing document reference with logicalId: ${docReference.logicalId}")
 
-                    val success = uploadDocumentReferenceVersionAware(docReference, fileUri, context, serverDocRef)
+                    val success =
+                        uploadDocumentReferenceVersionAware(
+                            docReference,
+                            fileUri,
+                            context,
+                            serverDocRef,
+                            pendingDocuments,
+                        )
 
                     if (success) {
                         // CRITICAL: Re-verify from server that image data exists before deleting locally.
@@ -282,7 +298,8 @@ private fun filesExists(uri: Uri?): Boolean {
         docReference: DocumentReference,
         fileUri: Uri,
         context: Context,
-        serverDocRef: DocumentReference?
+        serverDocRef: DocumentReference?,
+        pendingDocuments: Int,
     ): Boolean {
         return runCatching {
             Timber.i("Starting version-aware upload for document: ${docReference.logicalId}")
@@ -314,9 +331,7 @@ private fun filesExists(uri: Uri?): Boolean {
 
             // Step 3b: Upload the file's binary content if it's missing.
             if (!serverDocRef.hasImageDataOnServer()) {
-                val startTime = System.currentTimeMillis()
-                uploadFileContent(docReference, fileUri, context)
-                val timeTaken = System.currentTimeMillis() - startTime
+                val timeTaken = uploadFileContent(docReference, fileUri, context, pendingDocuments)
                 addUploadTimeTaken(docReference, timeTaken)
                 // Track progress in-memory only. Do NOT call openSrpFhirEngine.update()
                 // here — that queues a local change, and the subsequent super.doWork()
@@ -365,7 +380,12 @@ private fun filesExists(uri: Uri?): Boolean {
     /**
      * Step 2: Uploads the binary file content to the existing DocumentReference.
      */
-    private suspend fun uploadFileContent(docReference: DocumentReference, fileUri: Uri, context: Context) {
+    private suspend fun uploadFileContent(
+        docReference: DocumentReference,
+        fileUri: Uri,
+        context: Context,
+        pendingDocuments: Int,
+    ): Long {
         Timber.i("Step 2: Uploading file content for ${docReference.logicalId}")
 
         val bytes = context.contentResolver.openInputStream(fileUri)
@@ -375,14 +395,24 @@ private fun filesExists(uri: Uri?): Boolean {
         val contentType = docReference.content.firstOrNull()?.attachment?.contentType
         val body = bytes.toRequestBody(contentType?.toMediaType())
 
+        val startTime = System.currentTimeMillis()
         val response = fhirResourceService.uploadFile(
             docReference.fhirType(),
             docReference.logicalId,
             "DocumentReference.content.attachment",
             body
         )
+        val timeTaken = System.currentTimeMillis() - startTime
 
         if (!response.isSuccessful) {
+            captureImageUploadCompleted(
+                docReference = docReference,
+                uploadDurationMs = timeTaken,
+                responseCode = response.code(),
+                pendingDocuments = pendingDocuments,
+                bytesUploaded = bytes.size,
+                errorMessage = response.message(),
+            )
             docReference.addExtension().apply {
                 url = IMG_UPLOAD_ERROR_EXTENSION
                 setValue(StringType("Upload failed: ${response.code()} - ${response.message()}"))
@@ -399,10 +429,39 @@ private fun filesExists(uri: Uri?): Boolean {
                 documentId = docReference.logicalId,
                 responseCode = response.code(),
                 responseMessage = response.message(),
-                pendingDocuments = 0 // Caller can update this if needed
+                pendingDocuments = pendingDocuments
             )
         }
+        captureImageUploadCompleted(
+            docReference = docReference,
+            uploadDurationMs = timeTaken,
+            responseCode = response.code(),
+            pendingDocuments = pendingDocuments,
+            bytesUploaded = bytes.size,
+        )
         Timber.i("Step 2 completed: File content uploaded for ${docReference.logicalId}")
+        return timeTaken
+    }
+
+    private fun captureImageUploadCompleted(
+        docReference: DocumentReference,
+        uploadDurationMs: Long,
+        responseCode: Int,
+        pendingDocuments: Int,
+        bytesUploaded: Int,
+        errorMessage: String? = null,
+    ) {
+        analyticsLogger.capture(
+            AnalyticsLogger.Events.IMAGE_UPLOAD_COMPLETED,
+            mapOf(
+                AnalyticsLogger.Props.DOCUMENT_ID to docReference.logicalId,
+                AnalyticsLogger.Props.UPLOAD_DURATION_MS to uploadDurationMs,
+                AnalyticsLogger.Props.RESPONSE_CODE to responseCode,
+                AnalyticsLogger.Props.PENDING_DOCUMENTS to pendingDocuments,
+                AnalyticsLogger.Props.BYTES_UPLOADED to bytesUploaded,
+                AnalyticsLogger.Props.ERROR_MESSAGE to errorMessage,
+            ),
+        )
     }
 
     /**

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/util/analytics/AnalyticsLogger.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/util/analytics/AnalyticsLogger.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021-2024 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartregister.fhircore.engine.util.analytics
+
+interface AnalyticsLogger {
+  fun capture(event: String, properties: Map<String, Any?>? = null)
+
+  object Events {
+    const val IMAGE_UPLOAD_COMPLETED = "image_upload_completed"
+  }
+
+  object Props {
+    const val DOCUMENT_ID = "document_id"
+    const val UPLOAD_DURATION_MS = "upload_duration_ms"
+    const val RESPONSE_CODE = "response_code"
+    const val PENDING_DOCUMENTS = "pending_documents"
+    const val BYTES_UPLOADED = "bytes_uploaded"
+    const val ERROR_MESSAGE = "error_message"
+  }
+}

--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/util/analytics/AnalyticsLoggerEntryPoint.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/util/analytics/AnalyticsLoggerEntryPoint.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021-2024 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartregister.fhircore.engine.util.analytics
+
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface AnalyticsLoggerEntryPoint {
+  fun analyticsLogger(): AnalyticsLogger
+}

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/camerax/CameraxLauncherFragment.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/camerax/CameraxLauncherFragment.kt
@@ -70,9 +70,16 @@ import kotlin.math.exp
 import androidx.core.view.isVisible
 import com.google.android.fhir.FhirEngine
 import dagger.hilt.android.AndroidEntryPoint
+import org.opencv.android.Utils
+import org.opencv.core.Mat
+import org.opencv.imgproc.Imgproc
+import org.smartregister.fhircore.quest.util.DeviceMetrics
 import org.smartregister.fhircore.quest.util.FeatureFlagUtil
+import org.smartregister.fhircore.quest.util.ImageQualityAnalyzer
 import org.smartregister.fhircore.quest.util.PostHogAnalytics
+import org.smartregister.fhircore.quest.util.ScreeningTimer
 import javax.inject.Inject
+import kotlin.math.ln
 
 @AndroidEntryPoint
 class CameraxLauncherFragment : DialogFragment() {
@@ -109,6 +116,10 @@ class CameraxLauncherFragment : DialogFragment() {
     // Init runs concurrently with photo capture; onPhotoSelected awaits this before
     // running inference so the IO-thread forward pass can't race with module load.
     private var initModelJob: Job? = null
+    private var screeningId: String? = null
+    private var captureStartedMs: Long? = null
+    private var captureSavedMs: Long? = null
+    private var timeToCaptureMs: Long? = null
 
     private val requestPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
@@ -133,6 +144,7 @@ class CameraxLauncherFragment : DialogFragment() {
         super.onCreate(savedInstanceState)
         //setStyle(STYLE_NO_FRAME, android.R.style.Theme_Holo_Light)
         setStyle(DialogFragment.STYLE_NORMAL, android.R.style.Theme_Black_NoTitleBar_Fullscreen)
+        screeningId = arguments?.getString(ARG_SCREENING_ID)
     }
 
     override fun onCreateView(
@@ -184,6 +196,7 @@ class CameraxLauncherFragment : DialogFragment() {
         }
 
         retakeButton.setOnClickListener {
+            ScreeningTimer.incrementRetake(screeningId)
             val flashOfDrawable = context?.getDrawable(R.drawable.flash_off)
             flashButton.setImageDrawable(flashOfDrawable)
             isCapturing = false
@@ -359,6 +372,8 @@ class CameraxLauncherFragment : DialogFragment() {
         if (isCapturing) return
         isCapturing = true
         captureButton.isEnabled = false
+        captureStartedMs = SystemClock.elapsedRealtime()
+        ScreeningTimer.markStep(screeningId, "photo_capture_started")
         try {
             val file = File.createTempFile("IMG_", ".jpeg", requireContext().filesDir)
             val outputOptions = ImageCapture.OutputFileOptions.Builder(file).build()
@@ -366,6 +381,9 @@ class CameraxLauncherFragment : DialogFragment() {
             imageCapture.takePicture(
                 outputOptions, cameraExecutor, object : ImageCapture.OnImageSavedCallback {
                     override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
+                        captureSavedMs = SystemClock.elapsedRealtime()
+                        timeToCaptureMs = captureSavedMs?.minus(captureStartedMs ?: captureSavedMs ?: 0L)
+                        ScreeningTimer.markStep(screeningId, "photo_capture_completed")
                         cameraControl.enableTorch(false)
                         //cameraExecutor.shutdown()
                         lifecycleScope.launch {
@@ -481,60 +499,129 @@ class CameraxLauncherFragment : DialogFragment() {
         }
     }
 
-    private fun processImage(absolutePath: String): Map<String, Any>? {
-        //val processStartTime = System.currentTimeMillis()
-        try {
-            val processedImage = OpenCVUtils.decodeFileToMat(absolutePath) ?: throw IllegalArgumentException("Failed to decode image")
-            val tensorStartTime = System.currentTimeMillis()
-            //val mean = floatArrayOf(0.485f, 0.456f, 0.406f)
+    private fun processImage(absolutePath: String, runAiInference: Boolean): ImageProcessingResult? {
+        val sourceMat = OpenCVUtils.scaleImageMat(absolutePath)
+        if (sourceMat == null) {
+            PostHogAnalytics.captureError("CameraxLauncherFragment", "Image processing failed: unable to decode image")
+            return null
+        }
+
+        val rgbMat = Mat()
+        return try {
+            val qualityProps = ImageQualityAnalyzer.analyze(sourceMat)
+            if (!runAiInference) return ImageProcessingResult(emptyMap(), qualityProps, 0L)
+
+            Imgproc.cvtColor(sourceMat, rgbMat, Imgproc.COLOR_BGR2RGB)
+            val processedImage = Bitmap.createBitmap(rgbMat.cols(), rgbMat.rows(), Bitmap.Config.ARGB_8888)
+            Utils.matToBitmap(rgbMat, processedImage)
+
             val mean = floatArrayOf(0.0f, 0.0f, 0.0f)
-            //val std = floatArrayOf(0.229f, 0.224f, 0.225f)
             val std = floatArrayOf(1f, 1f, 1f)
 
             val inputTensor = TensorImageUtils.bitmapToFloat32Tensor(processedImage, mean, std)
             val bgrTensor = convertRGBtoBGR(inputTensor) ?: throw IllegalStateException("Failed to convert RGB to BGR")
             val inputIValue = IValue.from(bgrTensor)
 
-            val runInference = { module: Module?, name: String ->
-                val outputTensor = module?.forward(inputIValue)?.toTensor()
-                    ?: throw IllegalStateException("Module $name is null or forward operation failed")
-                var scores = outputTensor.dataAsFloatArray[0]
-                scores = 1 / (1 + exp(-scores))
-                val prediction = if (scores > 0.5f) 1 else 0
-                val className = classes.diseases[prediction]
-                val confidence = if (prediction == 1) (scores * 100).toString() else ((1 - scores) * 100).toString()
-                Triple(prediction == 1, className, confidence)
-            }
+            ScreeningTimer.markStep(screeningId, "ai_inference_started")
+            val result6 = runInference(inputIValue, module6, "v6")
+            val result8 = runInference(inputIValue, module8, "v8")
+            val result82 = runInference(inputIValue, module82, "v82")
+            val modelResults = listOf(result6, result8, result82)
 
-            val result6 = runInference(module6, "model6")
-            val result8 = runInference(module8, "model8")
-            val result82 = runInference(module82, "model82")
+            modelResults.forEach { captureModelInference(it) }
 
-            val allSuspicious = result6.first && result8.first && result82.first
+            val combinedInferenceTimeMs = modelResults.sumOf { it.inferenceTimeMs }
+            val allSuspicious = modelResults.all { it.isSuspicious }
             val finalPrediction = if (allSuspicious) 1 else 0
             val finalClassName = classes.diseases[finalPrediction]
+            val finalConfidenceValue = modelResults.map { it.confidence }.average().toFloat()
+            val finalConfidence = DecimalFormat("#.##").format(finalConfidenceValue)
+            val ensemble =
+                ModelInferenceResult(
+                    modelName = "ensemble",
+                    prediction = if (allSuspicious) "suspicious" else "non_suspicious",
+                    displayPrediction = finalClassName,
+                    confidence = finalConfidenceValue,
+                    probability = modelResults.map { it.probability }.average().toFloat(),
+                    entropy = modelResults.map { it.entropy }.average(),
+                    lowConfidence = finalConfidenceValue < LOW_CONFIDENCE_THRESHOLD,
+                    inferenceTimeMs = combinedInferenceTimeMs,
+                    combinedInferenceTimeMs = combinedInferenceTimeMs,
+                    isSuspicious = allSuspicious,
+                )
+            captureModelInference(ensemble)
+            ScreeningTimer.markStep(screeningId, "ai_inference_completed")
 
-            val avgConfidence = listOf(result6.third, result8.third, result82.third)
-                .mapNotNull { it.toFloatOrNull() }
-                .let { values -> if (values.isNotEmpty()) DecimalFormat("#.##").format(values.average()) else "" }
-            val finalConfidence = avgConfidence
             Timber.d("Final prediction: $finalPrediction, Class: $finalClassName")
-            return mapOf(
-                CAMERA_PREDICTION_KEY to finalClassName,
-                CAMERA_CONFIDENCE_KEY to finalConfidence,
-                "model6_prediction" to result6.second,
-                "model6_confidence" to result6.third,
-                "model8_prediction" to result8.second,
-                "model8_confidence" to result8.third,
-                "model82_prediction" to result82.second,
-                "model82_confidence" to result82.third,
+            ImageProcessingResult(
+                resultMap =
+                    mapOf(
+                        CAMERA_PREDICTION_KEY to finalClassName,
+                        CAMERA_CONFIDENCE_KEY to finalConfidence,
+                        "model6_prediction" to result6.displayPrediction,
+                        "model6_confidence" to result6.confidence.toString(),
+                        "model8_prediction" to result8.displayPrediction,
+                        "model8_confidence" to result8.confidence.toString(),
+                        "model82_prediction" to result82.displayPrediction,
+                        "model82_confidence" to result82.confidence.toString(),
+                    ),
+                qualityProps = qualityProps,
+                combinedInferenceTimeMs = combinedInferenceTimeMs,
             )
-
         } catch (e: Exception) {
             Log.d("Error", "Error processing image ${e.printStackTrace()}")
             PostHogAnalytics.captureError("CameraxLauncherFragment", "Image processing failed: ${e.message}")
-            return null
+            null
+        } finally {
+            sourceMat.release()
+            rgbMat.release()
         }
+    }
+
+    private fun runInference(inputIValue: IValue, module: Module?, modelName: String): ModelInferenceResult {
+        val startedMs = SystemClock.elapsedRealtime()
+        val outputTensor = module?.forward(inputIValue)?.toTensor()
+            ?: throw IllegalStateException("Module $modelName is null or forward operation failed")
+        val inferenceTimeMs = SystemClock.elapsedRealtime() - startedMs
+        val probability = sigmoid(outputTensor.dataAsFloatArray[0])
+        val prediction = if (probability > 0.5f) 1 else 0
+        val confidence = if (prediction == 1) probability * 100 else (1 - probability) * 100
+        return ModelInferenceResult(
+            modelName = modelName,
+            prediction = if (prediction == 1) "suspicious" else "non_suspicious",
+            displayPrediction = classes.diseases[prediction],
+            confidence = confidence,
+            probability = probability,
+            entropy = binaryEntropy(probability),
+            // Low-confidence is evaluated on the predicted side of 50%; 65% is the V1 launch cut.
+            lowConfidence = confidence < LOW_CONFIDENCE_THRESHOLD,
+            inferenceTimeMs = inferenceTimeMs,
+            isSuspicious = prediction == 1,
+        )
+    }
+
+    private fun captureModelInference(result: ModelInferenceResult) {
+        PostHogAnalytics.capture(
+            PostHogAnalytics.Events.MODEL_INFERENCE_COMPLETED,
+            mapOf(
+                PostHogAnalytics.Props.SCREENING_ID to screeningId,
+                PostHogAnalytics.Props.MODEL_NAME to result.modelName,
+                PostHogAnalytics.Props.MODEL_VERSION to MODEL_VERSION,
+                PostHogAnalytics.Props.MODEL_PREDICTION to result.prediction,
+                PostHogAnalytics.Props.MODEL_CONFIDENCE to result.confidence,
+                PostHogAnalytics.Props.MODEL_ENTROPY to result.entropy,
+                PostHogAnalytics.Props.LOW_CONFIDENCE to result.lowConfidence,
+                PostHogAnalytics.Props.INFERENCE_TIME_MS to result.inferenceTimeMs,
+                PostHogAnalytics.Props.COMBINED_INFERENCE_TIME_MS to result.combinedInferenceTimeMs,
+            ),
+        )
+    }
+
+    private fun sigmoid(value: Float): Float = (1 / (1 + exp(-value))).toFloat()
+
+    private fun binaryEntropy(probability: Float): Double {
+        val p = probability.coerceIn(0.000001f, 0.999999f).toDouble()
+        return -p * ln(p) - (1 - p) * ln(1 - p)
     }
 
     fun View.setSafeOnClickListener(interval: Long = 1000, onSafeClick: (View) -> Unit) {
@@ -550,21 +637,38 @@ class CameraxLauncherFragment : DialogFragment() {
         setOnClickListener(safeClickListener)
     }
     private suspend fun onPhotoSelected(absolutePath : String){
-        val resultMap = if (isAiInferenceEnabled()) {
+        val aiEnabled = isAiInferenceEnabled()
+        val processingResult = if (aiEnabled) {
             // Wait for model load to finish before forwarding on Dispatchers.IO.
             // Without this the IO-thread forward pass can race with model load on
             // Main, hit a null Module, throw, and surface as "Error" — which the
             // case-level combine then reads as Non-Suspicious (false negative).
             initModelJob?.join()
             withContext(Dispatchers.IO) {
-                processImage(fileAbsPath)
+                processImage(fileAbsPath, runAiInference = true)
             }
-        } else null
+        } else {
+            withContext(Dispatchers.IO) {
+                processImage(fileAbsPath, runAiInference = false)
+            }
+        }
+        val resultMap = processingResult?.resultMap?.takeIf { it.isNotEmpty() }
 
         val predictionProps = mutableMapOf<String, Any>(
             PostHogAnalytics.Props.AI_PREDICTION to (resultMap?.get(CAMERA_PREDICTION_KEY) ?: ""),
             PostHogAnalytics.Props.AI_CONFIDENCE to (resultMap?.get(CAMERA_CONFIDENCE_KEY) ?: ""),
         )
+        ScreeningTimer.incrementPhoto(screeningId)
+        val captureToResultMs = captureSavedMs?.let { SystemClock.elapsedRealtime() - it }
+        predictionProps[PostHogAnalytics.Props.SCREENING_ID] = screeningId.orEmpty()
+        timeToCaptureMs?.let { predictionProps[PostHogAnalytics.Props.TIME_TO_CAPTURE_MS] = it }
+        captureToResultMs?.let { predictionProps[PostHogAnalytics.Props.CAPTURE_TO_RESULT_MS] = it }
+        processingResult?.qualityProps?.let { predictionProps.putAll(it) }
+        predictionProps.putAll(DeviceMetrics.snapshot(requireContext()))
+        if (processingResult != null) {
+            predictionProps[PostHogAnalytics.Props.INFERENCE_TIME_MS] = processingResult.combinedInferenceTimeMs
+            predictionProps[PostHogAnalytics.Props.COMBINED_INFERENCE_TIME_MS] = processingResult.combinedInferenceTimeMs
+        }
         PostHogAnalytics.capture(PostHogAnalytics.Events.PHOTO_CAPTURED, predictionProps)
 
         setFragmentResult(CAMERA_RESULT_KEY, Bundle().apply {
@@ -581,13 +685,13 @@ class CameraxLauncherFragment : DialogFragment() {
 
                 putString(CAMERA_MODEL82_PREDICTION_KEY, resultMap["model82_prediction"] as String)
                 putString(CAMERA_MODEL82_CONFIDENCE_KEY, resultMap["model82_confidence"] as String)
-            } else if (isAiInferenceEnabled()) {
+            } else if (aiEnabled) {
                 putString(CAMERA_PREDICTION_KEY, "")
                 putString(CAMERA_CONFIDENCE_KEY, "")
             }
             putBoolean(CAMERA_RESULT_KEY, true)
         })
-        val message = if (isAiInferenceEnabled()) "Image processed successfully" else "Image saved successfully"
+        val message = if (aiEnabled) "Image processed successfully" else "Image saved successfully"
         activity?.showToast(message, Toast.LENGTH_SHORT)
         dismiss()
     }
@@ -599,8 +703,30 @@ class CameraxLauncherFragment : DialogFragment() {
         }
     }
 
+    private data class ImageProcessingResult(
+        val resultMap: Map<String, Any>,
+        val qualityProps: Map<String, Any>,
+        val combinedInferenceTimeMs: Long,
+    )
+
+    private data class ModelInferenceResult(
+        val modelName: String,
+        val prediction: String,
+        val displayPrediction: String,
+        val confidence: Float,
+        val probability: Float,
+        val entropy: Double,
+        val lowConfidence: Boolean,
+        val inferenceTimeMs: Long,
+        val combinedInferenceTimeMs: Long? = null,
+        val isSuspicious: Boolean,
+    )
+
     companion object {
         private const val ARG_SAVED_PHOTO_URI = "arg_saved_photo_uri"
+        private const val ARG_SCREENING_ID = "arg_screening_id"
+        private const val MODEL_VERSION = "v38"
+        private const val LOW_CONFIDENCE_THRESHOLD = 65f
         const val CAMERA_RESULT_KEY = "camera_result"
         const val CAMERA_RESULT_URI_KEY = "camera_result_uri"
         const val CAMERA_PREDICTION_KEY = "camera_prediction"
@@ -613,8 +739,12 @@ class CameraxLauncherFragment : DialogFragment() {
         const val CAMERA_MODEL82_PREDICTION_KEY = "camera_model82_prediction"
         const val CAMERA_MODEL82_CONFIDENCE_KEY = "camera_model82_confidence"
 
-        fun newInstance(): CameraxLauncherFragment {
-            return CameraxLauncherFragment()
+        fun newInstance(screeningId: String? = null): CameraxLauncherFragment {
+            return CameraxLauncherFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_SCREENING_ID, screeningId)
+                }
+            }
         }
     }
 }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/camerax/CameraxLauncherFragment.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/camerax/CameraxLauncherFragment.kt
@@ -562,8 +562,8 @@ class CameraxLauncherFragment : DialogFragment() {
         } else null
 
         val predictionProps = mutableMapOf<String, Any>(
-            PostHogAnalytics.Props.AI_PREDICTION to (resultMap?.get(CAMERA_PREDICTION_KEY) ?: "none"),
-            PostHogAnalytics.Props.AI_CONFIDENCE to (resultMap?.get(CAMERA_CONFIDENCE_KEY) ?: "none"),
+            PostHogAnalytics.Props.AI_PREDICTION to (resultMap?.get(CAMERA_PREDICTION_KEY) ?: ""),
+            PostHogAnalytics.Props.AI_CONFIDENCE to (resultMap?.get(CAMERA_CONFIDENCE_KEY) ?: ""),
         )
         PostHogAnalytics.capture(PostHogAnalytics.Events.PHOTO_CAPTURED, predictionProps)
 
@@ -582,8 +582,8 @@ class CameraxLauncherFragment : DialogFragment() {
                 putString(CAMERA_MODEL82_PREDICTION_KEY, resultMap["model82_prediction"] as String)
                 putString(CAMERA_MODEL82_CONFIDENCE_KEY, resultMap["model82_confidence"] as String)
             } else if (isAiInferenceEnabled()) {
-                putString(CAMERA_PREDICTION_KEY, "Error")
-                putString(CAMERA_CONFIDENCE_KEY, "Error")
+                putString(CAMERA_PREDICTION_KEY, "")
+                putString(CAMERA_CONFIDENCE_KEY, "")
             }
             putBoolean(CAMERA_RESULT_KEY, true)
         })

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/camerax/CameraxLauncherFragment.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/camerax/CameraxLauncherFragment.kt
@@ -47,6 +47,7 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.google.common.util.concurrent.ListenableFuture
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.pytorch.IValue
@@ -102,9 +103,12 @@ class CameraxLauncherFragment : DialogFragment() {
 
     private var fileAbsPath: String = ""
     private var isCapturing = false
-    var module6 : Module? = null
-    var module8 : Module? = null
-    var module82 : Module? = null
+    @Volatile var module6 : Module? = null
+    @Volatile var module8 : Module? = null
+    @Volatile var module82 : Module? = null
+    // Init runs concurrently with photo capture; onPhotoSelected awaits this before
+    // running inference so the IO-thread forward pass can't race with module load.
+    private var initModelJob: Job? = null
 
     private val requestPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
@@ -208,7 +212,7 @@ class CameraxLauncherFragment : DialogFragment() {
 
         checkPermissionAndStartCamera()
 
-        lifecycleScope.launch {
+        initModelJob = lifecycleScope.launch {
             if (isAiInferenceEnabled()) {
                 initModel()
             }
@@ -394,7 +398,7 @@ class CameraxLauncherFragment : DialogFragment() {
                     override fun onError(exception: ImageCaptureException) {
                         isCapturing = false
                         lifecycleScope.launch {
-                             captureButton.isEnabled = true
+                            captureButton.isEnabled = true
                         }
                         Timber.e(exception,"Photo exception = {ImageCaptureException@35501} \"androidx.camera.core.ImageCaptureException: Failed to write temp file\"capture failed: ${exception.message}")
                         dismiss()
@@ -509,7 +513,7 @@ class CameraxLauncherFragment : DialogFragment() {
             val allSuspicious = result6.first && result8.first && result82.first
             val finalPrediction = if (allSuspicious) 1 else 0
             val finalClassName = classes.diseases[finalPrediction]
-            
+
             val avgConfidence = listOf(result6.third, result8.third, result82.third)
                 .mapNotNull { it.toFloatOrNull() }
                 .let { values -> if (values.isNotEmpty()) DecimalFormat("#.##").format(values.average()) else "" }
@@ -547,6 +551,11 @@ class CameraxLauncherFragment : DialogFragment() {
     }
     private suspend fun onPhotoSelected(absolutePath : String){
         val resultMap = if (isAiInferenceEnabled()) {
+            // Wait for model load to finish before forwarding on Dispatchers.IO.
+            // Without this the IO-thread forward pass can race with model load on
+            // Main, hit a null Module, throw, and surface as "Error" — which the
+            // case-level combine then reads as Non-Suspicious (false negative).
+            initModelJob?.join()
             withContext(Dispatchers.IO) {
                 processImage(fileAbsPath)
             }
@@ -563,18 +572,18 @@ class CameraxLauncherFragment : DialogFragment() {
             if (resultMap != null) {
                 putString(CAMERA_PREDICTION_KEY, resultMap[CAMERA_PREDICTION_KEY] as String)
                 putString(CAMERA_CONFIDENCE_KEY, resultMap[CAMERA_CONFIDENCE_KEY] as String)
-                
+
                 putString(CAMERA_MODEL6_PREDICTION_KEY, resultMap["model6_prediction"] as String)
                 putString(CAMERA_MODEL6_CONFIDENCE_KEY, resultMap["model6_confidence"] as String)
-                
+
                 putString(CAMERA_MODEL8_PREDICTION_KEY, resultMap["model8_prediction"] as String)
                 putString(CAMERA_MODEL8_CONFIDENCE_KEY, resultMap["model8_confidence"] as String)
-                
+
                 putString(CAMERA_MODEL82_PREDICTION_KEY, resultMap["model82_prediction"] as String)
                 putString(CAMERA_MODEL82_CONFIDENCE_KEY, resultMap["model82_confidence"] as String)
             } else if (isAiInferenceEnabled()) {
-                 putString(CAMERA_PREDICTION_KEY, "Error")
-                 putString(CAMERA_CONFIDENCE_KEY, "Error")
+                putString(CAMERA_PREDICTION_KEY, "Error")
+                putString(CAMERA_CONFIDENCE_KEY, "Error")
             }
             putBoolean(CAMERA_RESULT_KEY, true)
         })
@@ -596,7 +605,7 @@ class CameraxLauncherFragment : DialogFragment() {
         const val CAMERA_RESULT_URI_KEY = "camera_result_uri"
         const val CAMERA_PREDICTION_KEY = "camera_prediction"
         const val CAMERA_CONFIDENCE_KEY = "camera_confidence"
-        
+
         const val CAMERA_MODEL6_PREDICTION_KEY = "camera_model6_prediction"
         const val CAMERA_MODEL6_CONFIDENCE_KEY = "camera_model6_confidence"
         const val CAMERA_MODEL8_PREDICTION_KEY = "camera_model8_prediction"

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/di/AnalyticsModule.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/di/AnalyticsModule.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021-2024 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartregister.fhircore.quest.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.smartregister.fhircore.engine.util.analytics.AnalyticsLogger
+import org.smartregister.fhircore.quest.util.PostHogAnalyticsLogger
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AnalyticsModule {
+  @Binds abstract fun bindAnalyticsLogger(logger: PostHogAnalyticsLogger): AnalyticsLogger
+}

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/main/AppMainViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/main/AppMainViewModel.kt
@@ -17,6 +17,7 @@
 package org.smartregister.fhircore.quest.ui.main
 
 import android.content.Context
+import android.os.SystemClock
 import android.widget.Toast
 import androidx.core.os.bundleOf
 import androidx.lifecycle.ViewModel
@@ -26,12 +27,14 @@ import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.workDataOf
 import com.google.android.fhir.FhirEngine
+import com.google.android.fhir.search.search
 import com.google.android.fhir.sync.CurrentSyncJobStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.smartregister.fhircore.quest.util.PostHogAnalytics
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.hl7.fhir.r4.model.Binary
+import org.hl7.fhir.r4.model.DocumentReference
 import org.hl7.fhir.r4.model.Enumerations
 import org.hl7.fhir.r4.model.QuestionnaireResponse
 import org.hl7.fhir.r4.model.ResourceType
@@ -46,6 +49,7 @@ import org.smartregister.fhircore.engine.configuration.navigation.ICON_TYPE_REMO
 import org.smartregister.fhircore.engine.configuration.navigation.NavigationConfiguration
 import org.smartregister.fhircore.engine.configuration.report.measure.MeasureReportConfiguration
 import org.smartregister.fhircore.engine.data.local.register.RegisterRepository
+import org.smartregister.fhircore.engine.domain.networkUtils.DocumentReferenceCaseType
 import org.smartregister.fhircore.engine.domain.model.ActionParameter
 import org.smartregister.fhircore.engine.domain.model.ActionParameterType
 import org.smartregister.fhircore.engine.sync.SyncBroadcaster
@@ -98,6 +102,7 @@ constructor(
 ) : ViewModel() {
 
   private val simpleDateFormat = SimpleDateFormat(SYNC_TIMESTAMP_OUTPUT_FORMAT, Locale.getDefault())
+  private var syncStartedAtMs: Long? = null
 
   val applicationConfiguration: ApplicationConfiguration by lazy {
     configurationRegistry.retrieveConfiguration(ConfigType.Application, paramsMap = emptyMap())
@@ -130,11 +135,15 @@ constructor(
   }
 
   fun setPostHogUserProperties() {
-    try {
-      val flwId = secureSharedPreference.getPractitionerUserId()
-      PostHogAnalytics.identifyUser(flwId = flwId)
-    } catch (e: Exception) {
-      Timber.e(e)
+    viewModelScope.launch(dispatcherProvider.io()) {
+      try {
+        updatePostHogUserProperties(
+          pendingSyncImages = pendingSyncImages(),
+          pendingSyncCases = pendingSyncCases(),
+        )
+      } catch (e: Exception) {
+        Timber.e(e)
+      }
     }
   }
 
@@ -151,6 +160,8 @@ constructor(
       is AppMainEvent.SyncData -> {
         Timber.e("TAG SyncData onEvent --> isForeground -->$isForeground event--> ${event}")
         if (event.context.isDeviceOnline()) {
+          syncStartedAtMs = SystemClock.elapsedRealtime()
+          PostHogAnalytics.capture(PostHogAnalytics.Events.SYNC_INITIATED)
           setPostHogUserProperties()
           if (!isForeground) {
             viewModelScope.launch { syncBroadcaster.runOneTimeSync() }
@@ -169,6 +180,12 @@ constructor(
             SharedPreferenceKey.LAST_SYNC_TIMESTAMP.name,
             formatLastSyncTimestamp(event.state.timestamp),
           )
+        }
+        if (
+          event.state is CurrentSyncJobStatus.Succeeded ||
+            event.state is CurrentSyncJobStatus.Failed
+        ) {
+          captureSyncCompleted(event.state)
         }
       }
       is AppMainEvent.TriggerWorkflow ->
@@ -200,6 +217,52 @@ constructor(
         )
         .run { show(activity.supportFragmentManager, RegisterBottomSheetFragment.TAG) }
     }
+  }
+
+  private fun captureSyncCompleted(state: CurrentSyncJobStatus) {
+    viewModelScope.launch(dispatcherProvider.io()) {
+      val pendingImages = pendingSyncImages()
+      val pendingCases = pendingSyncCases()
+      val syncDuration = syncStartedAtMs?.let { SystemClock.elapsedRealtime() - it }
+      val syncStatus =
+        when (state) {
+          is CurrentSyncJobStatus.Succeeded -> "succeeded"
+          is CurrentSyncJobStatus.Failed -> "failed"
+          else -> return@launch
+        }
+
+      PostHogAnalytics.capture(
+        PostHogAnalytics.Events.SYNC_COMPLETED,
+        mapOf(
+          PostHogAnalytics.Props.SYNC_STATUS to syncStatus,
+          PostHogAnalytics.Props.SYNC_DURATION_MS to syncDuration,
+          PostHogAnalytics.Props.PENDING_IMAGES_AFTER to pendingImages,
+          PostHogAnalytics.Props.PENDING_CASES_AFTER to pendingCases,
+          PostHogAnalytics.Props.ERROR_MESSAGE to
+            (state as? CurrentSyncJobStatus.Failed)?.toString(),
+        ),
+      )
+      updatePostHogUserProperties(
+        pendingSyncImages = pendingImages,
+        pendingSyncCases = pendingCases,
+      )
+      syncStartedAtMs = null
+    }
+  }
+
+  private suspend fun pendingSyncImages(): Int =
+    fhirEngine.search<DocumentReference> {}
+      .count { it.resource.description != DocumentReferenceCaseType.DRAFT }
+
+  private suspend fun pendingSyncCases(): Int = fhirEngine.getUnsyncedLocalChanges().size
+
+  private fun updatePostHogUserProperties(pendingSyncImages: Int, pendingSyncCases: Int) {
+    val flwId = secureSharedPreference.getPractitionerUserId()
+    PostHogAnalytics.identifyUser(
+      flwId = flwId,
+      pendingSyncImages = pendingSyncImages,
+      pendingSyncCases = pendingSyncCases,
+    )
   }
 
   fun launchFamilyRegistrationWithLocationId(

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/AIResultActivity.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/AIResultActivity.kt
@@ -6,7 +6,11 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import androidx.lifecycle.lifecycleScope
 import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -38,28 +42,50 @@ import org.smartregister.fhircore.engine.ui.theme.LighterBlue
 import org.smartregister.fhircore.engine.ui.theme.PrimaryColor
 import org.smartregister.fhircore.quest.R
 import org.smartregister.fhircore.quest.util.PostHogAnalytics
+import org.smartregister.fhircore.quest.util.ScreeningTimer
 import org.smartregister.fhircore.quest.theme.Colors
 import org.smartregister.fhircore.quest.theme.Colors.WHITE
 import org.smartregister.fhircore.quest.theme.body18Medium
 import org.smartregister.fhircore.quest.ui.register.customui.ZoomableImageView
 
 class AIResultActivity : ComponentActivity() {
+
+    private val previewCacheDir by lazy {
+        File(cacheDir, "ai_result_preview").also { it.mkdirs() }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         val isSuspicious = intent.getBooleanExtra("isSuspicious", false)
         val suspiciousImages = intent.getStringArrayListExtra("suspiciousImages") ?: emptyList<String>()
+        val screeningId = intent.getStringExtra(PostHogAnalytics.Props.SCREENING_ID)
 
+        ScreeningTimer.markStep(screeningId, "ai_result_viewed")
         PostHogAnalytics.capture(
             PostHogAnalytics.Events.AI_RESULT_VIEWED,
-            mapOf(PostHogAnalytics.Props.IS_SUSPICIOUS to isSuspicious),
+            mapOf(
+                PostHogAnalytics.Props.IS_SUSPICIOUS to isSuspicious,
+                PostHogAnalytics.Props.SCREENING_ID to screeningId,
+            ),
         )
+
+        // Copy images to a private cache dir off the main thread. Sync worker only deletes after a
+        // successful network upload + server verification, so this copy always wins the race.
+        // Copies are cleaned up in onDestroy.
+        var displayImages by mutableStateOf(if (isSuspicious) suspiciousImages else emptyList<String>())
+        if (isSuspicious && suspiciousImages.isNotEmpty()) {
+            lifecycleScope.launch(Dispatchers.IO) {
+                val cached = suspiciousImages.mapNotNull { copyToPreviewCache(it) }
+                withContext(Dispatchers.Main) { displayImages = cached }
+            }
+        }
 
         setContent {
             MaterialTheme {
                 AIResultScreen(
                     isSuspicious = isSuspicious,
-                    suspiciousImages = suspiciousImages,
+                    suspiciousImages = displayImages,
                     onClose = {
                         intent.putExtra("refer_case", false)
                         setResult(RESULT_OK, intent)
@@ -68,7 +94,10 @@ class AIResultActivity : ComponentActivity() {
                     onRefer = {
                         PostHogAnalytics.capture(
                             PostHogAnalytics.Events.AI_REFER_CASE,
-                            mapOf(PostHogAnalytics.Props.IS_SUSPICIOUS to isSuspicious),
+                            mapOf(
+                                PostHogAnalytics.Props.IS_SUSPICIOUS to isSuspicious,
+                                PostHogAnalytics.Props.SCREENING_ID to screeningId,
+                            ),
                         )
                         intent.putExtra("refer_case", true)
                         setResult(RESULT_OK, intent)
@@ -76,6 +105,34 @@ class AIResultActivity : ComponentActivity() {
                     }
                 )
             }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        previewCacheDir.deleteRecursively()
+    }
+
+    private fun copyToPreviewCache(sourcePath: String): String? {
+        val path = sourcePath.trim()
+        if (path.isEmpty()) return null
+        return try {
+            val destFile = File(previewCacheDir, "${path.hashCode()}.img")
+            if (destFile.exists() && destFile.length() > 0) return destFile.absolutePath
+
+            val uri = Uri.parse(path)
+            val inputStream = when (uri.scheme?.lowercase()) {
+                "content" -> contentResolver.openInputStream(uri)
+                "file" -> File(uri.path ?: return null).takeIf { it.isFile }?.inputStream()
+                else -> File(path).takeIf { it.isFile }?.inputStream()
+                    ?: File(filesDir, path).takeIf { it.isFile }?.inputStream()
+                    ?: File(cacheDir, path).takeIf { it.isFile }?.inputStream()
+            } ?: return null
+
+            inputStream.use { input -> destFile.outputStream().use { input.copyTo(it) } }
+            destFile.absolutePath
+        } catch (e: Exception) {
+            null
         }
     }
 }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/AIResultActivity.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/AIResultActivity.kt
@@ -1,5 +1,7 @@
 package org.smartregister.fhircore.quest.ui.questionnaire
 
+import android.content.Context
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
@@ -86,9 +88,16 @@ fun AIResultScreen(
     onClose: () -> Unit,
     onRefer: () -> Unit
 ) {
+    val context = LocalContext.current
     val backgroundColor = if (isSuspicious) Colors.CORNSILK else LighterBlue
     val title = if (isSuspicious) stringResource(R.string.add_patient) else "AI Result"
     var fullScreenImageUrl by remember { mutableStateOf<String?>(null) }
+    val displayableSuspiciousImages = remember(context, suspiciousImages) {
+        suspiciousImages
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && resolveImageLoadModel(context, it) != null }
+            .distinct()
+    }
 
     Column(
         modifier = Modifier
@@ -193,12 +202,12 @@ fun AIResultScreen(
                     modifier = Modifier.padding(bottom = 12.dp)
                 )
 
-                if (isSuspicious && suspiciousImages.isNotEmpty()) {
+                if (isSuspicious && displayableSuspiciousImages.isNotEmpty()) {
                     LazyRow(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        items(suspiciousImages) { imagePath ->
+                        items(displayableSuspiciousImages, key = { it }) { imagePath ->
                             Box(
                                 modifier = Modifier
                                     .size(width = 264.dp, height = 237.dp)
@@ -333,6 +342,7 @@ fun LocalGlideImage(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
+    val imageModel = remember(context, path) { resolveImageLoadModel(context, path) }
     AndroidView(
         factory = { ctx ->
             androidx.appcompat.widget.AppCompatImageView(ctx).apply {
@@ -341,12 +351,16 @@ fun LocalGlideImage(
         },
         modifier = modifier,
         update = { view ->
-            val finalPath = if (File(path).isAbsolute) path else File(context.filesDir, path).absolutePath
-            Glide.with(view.context)
-                .load(finalPath)
-                .placeholder(android.R.drawable.ic_menu_gallery)
-                .error(android.R.drawable.ic_menu_gallery)
-                .into(view)
+            if (imageModel == null) {
+                Glide.with(view.context).clear(view)
+                view.setImageResource(android.R.drawable.ic_menu_gallery)
+            } else {
+                Glide.with(view.context)
+                    .load(imageModel)
+                    .placeholder(android.R.drawable.ic_menu_gallery)
+                    .error(android.R.drawable.ic_menu_gallery)
+                    .into(view)
+            }
         }
     )
 }
@@ -357,7 +371,7 @@ fun FullscreenImageOverlay(
     onClose: () -> Unit
 ) {
     val context = LocalContext.current
-    val finalPath = if (File(path).isAbsolute) path else File(context.filesDir, path).absolutePath
+    val imageModel = remember(context, path) { resolveImageLoadModel(context, path) }
     Dialog(
         onDismissRequest = onClose,
         properties = DialogProperties(
@@ -381,7 +395,7 @@ fun FullscreenImageOverlay(
                 modifier = Modifier.fillMaxSize(),
                 update = { view ->
                     Glide.with(view.context)
-                        .load(finalPath)
+                        .load(imageModel)
                         .error(android.R.drawable.ic_menu_delete)
                         .into(view)
                 }
@@ -408,3 +422,31 @@ fun FullscreenImageOverlay(
         }
     }
 }
+
+private fun resolveImageLoadModel(context: Context, rawPath: String): Any? {
+    val path = rawPath.trim()
+    if (path.isEmpty()) return null
+
+    val uri = Uri.parse(path)
+    when (uri.scheme?.lowercase()) {
+        "content" -> return uri.takeIf { context.canOpenUri(it) }
+        "file" -> return uri.path
+            ?.let(::File)
+            ?.takeIf { it.isFile }
+            ?.let { Uri.fromFile(it) }
+        "http", "https" -> return path
+    }
+
+    val directFile = File(path)
+    if (directFile.isAbsolute) return directFile.takeIf { it.isFile }
+
+    return listOf(
+        File(context.filesDir, path),
+        File(context.cacheDir, path),
+    ).firstOrNull { it.isFile }
+}
+
+private fun Context.canOpenUri(uri: Uri): Boolean =
+    runCatching {
+        contentResolver.openInputStream(uri)?.use { true } == true
+    }.getOrDefault(false)

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireActivity.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireActivity.kt
@@ -66,12 +66,14 @@ import org.smartregister.fhircore.quest.R
 import org.smartregister.fhircore.quest.databinding.QuestionnaireActivityBinding
 import org.smartregister.fhircore.quest.ui.register.patients.DocumentReferenceCaseType
 import org.smartregister.fhircore.quest.util.CASE_LEVEL_AI_RESULT_LINK_ID
+import org.smartregister.fhircore.quest.util.DeviceMetrics
 import org.smartregister.fhircore.quest.util.LocationUtils
 import org.smartregister.fhircore.quest.util.PermissionUtils
 import org.smartregister.fhircore.quest.util.REFER_CASE_URL
 import org.smartregister.fhircore.quest.util.ResourceUtils
 import org.smartregister.fhircore.quest.util.FeatureFlagUtil
 import org.smartregister.fhircore.quest.util.PostHogAnalytics
+import org.smartregister.fhircore.quest.util.ScreeningTimer
 import timber.log.Timber
 import java.io.Serializable
 import java.util.LinkedList
@@ -97,17 +99,28 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
   private var suspiciousImagesList: List<String> = emptyList()
   private var submissionIdTypes: List<IdType>? = null
   private var submissionQRResult: QuestionnaireResponse? = null
+  private var screeningId: String? = null
 
   private val aiResultLauncher =
     registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
       if (result.resultCode == Activity.RESULT_OK) {
         val referCase = result.data?.getBooleanExtra("refer_case", false) ?: false
+        val aiVerdict = if (isSuspiciousResult) "suspicious" else "non_suspicious"
         PostHogAnalytics.capture(
           PostHogAnalytics.Events.QUESTIONNAIRE_SUBMITTED,
-          mapOf(
-            PostHogAnalytics.Props.QUESTIONNAIRE_ID to (if (::questionnaireConfig.isInitialized) questionnaireConfig.id else "unknown"),
+          questionnaireAnalyticsProps(
             PostHogAnalytics.Props.REFER_CASE to referCase,
+            PostHogAnalytics.Props.AI_VERDICT to aiVerdict,
+            PostHogAnalytics.Props.AI_OVERRIDDEN to (referCase && !isSuspiciousResult),
           ),
+        )
+        ScreeningTimer.end(
+          screeningId,
+          outcome = if (referCase) "refer_case" else "submitted",
+          extraProps =
+            screeningCompletionProps(
+              PostHogAnalytics.Props.IS_SUSPICIOUS to isSuspiciousResult,
+            ),
         )
 
         if (referCase) {
@@ -148,6 +161,10 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
       return
     }
 
+    if (isFreshRegistrationQuestionnaire()) {
+      screeningId = ScreeningTimer.start(DeviceMetrics.batteryPct(this))
+    }
+
     viewModel.questionnaireProgressStateLiveData.observe(this) { progressState ->
       alertDialog =
         if (progressState?.active == false) {
@@ -169,7 +186,7 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
     PostHogAnalytics.captureScreenView("QuestionnaireActivity")
     PostHogAnalytics.capture(
       PostHogAnalytics.Events.QUESTIONNAIRE_OPENED,
-      mapOf(PostHogAnalytics.Props.QUESTIONNAIRE_ID to questionnaireConfig.id),
+      questionnaireAnalyticsProps(),
     )
 
     setupLocationServices()
@@ -316,6 +333,7 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
           }
 
           registerFragmentResultListener()
+          ScreeningTimer.markStep(screeningId, "questionnaire_loaded")
         } catch (nullPointerException: NullPointerException) {
           Timber.e(nullPointerException, "questionnaire_not_found")
           showToast(getString(R.string.questionnaire_not_found))
@@ -498,18 +516,27 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
               }
               questionnaireResponse.addItem(aiResultItem)
 
+              val aiInferenceProps =
+                questionnaireAnalyticsProps(
+                    PostHogAnalytics.Props.IS_SUSPICIOUS to isSuspicious,
+                    PostHogAnalytics.Props.IMAGE_COUNT to aiSummary.imageCount,
+                    PostHogAnalytics.Props.SUSPICIOUS_IMAGE_COUNT to aiSummary.suspiciousImageCount,
+                    PostHogAnalytics.Props.NON_SUSPICIOUS_IMAGE_COUNT to aiSummary.nonSuspiciousImageCount,
+                    PostHogAnalytics.Props.LOW_CONFIDENCE_IMAGE_COUNT to aiSummary.lowConfidenceImageCount,
+                    PostHogAnalytics.Props.MEAN_CONFIDENCE to aiSummary.meanConfidence,
+                  )
+                  .toMutableMap()
+                  .apply { putAll(DeviceMetrics.snapshot(this@QuestionnaireActivity)) }
               PostHogAnalytics.capture(
                 PostHogAnalytics.Events.AI_INFERENCE_COMPLETED,
-                mapOf(
-                  PostHogAnalytics.Props.IS_SUSPICIOUS to isSuspicious,
-                  PostHogAnalytics.Props.QUESTIONNAIRE_ID to questionnaireConfig.id,
-                ),
+                aiInferenceProps,
               )
               Timber.d("=== About to launch AIResultActivity ===")
               currentQR = questionnaireResponse
               isSuspiciousResult = isSuspicious
               suspiciousImagesList = suspiciousImages
 
+              ScreeningTimer.markStep(screeningId, "submission_started")
               viewModel.setProgressState(QuestionnaireProgressState.ExtractionInProgress(true))
               viewModel.handleQuestionnaireSubmission(
                 questionnaire = questionnaire!!,
@@ -521,11 +548,13 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
                 viewModel.setProgressState(QuestionnaireProgressState.ExtractionInProgress(false))
                 submissionIdTypes = idTypes
                 submissionQRResult = qrResult
+                ScreeningTimer.markStep(screeningId, "submission_completed")
 
                 val intent = Intent(this@QuestionnaireActivity, AIResultActivity::class.java)
                 intent.putExtra("isSuspicious", isSuspicious)
                 intent.putStringArrayListExtra("suspiciousImages", ArrayList(suspiciousImages))
                 intent.putExtra("questionnaireResponseId", qrResult.logicalId)
+                intent.putExtra(PostHogAnalytics.Props.SCREENING_ID, screeningId)
                 aiResultLauncher.launch(intent)
               }
             } else {
@@ -533,8 +562,12 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
               Timber.d("=== AI inference disabled, submitting directly ===")
               PostHogAnalytics.capture(
                 PostHogAnalytics.Events.QUESTIONNAIRE_SUBMITTED,
-                mapOf(PostHogAnalytics.Props.QUESTIONNAIRE_ID to questionnaireConfig.id),
+                questionnaireAnalyticsProps(
+                  PostHogAnalytics.Props.AI_VERDICT to "disabled",
+                  PostHogAnalytics.Props.AI_OVERRIDDEN to false,
+                ),
               )
+              ScreeningTimer.markStep(screeningId, "submission_started")
               viewModel.setProgressState(QuestionnaireProgressState.ExtractionInProgress(true))
               viewModel.handleQuestionnaireSubmission(
                 questionnaire = questionnaire!!,
@@ -544,6 +577,12 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
                 context = this@QuestionnaireActivity,
               ) { idTypes, qrResult ->
                 viewModel.setProgressState(QuestionnaireProgressState.ExtractionInProgress(false))
+                ScreeningTimer.markStep(screeningId, "submission_completed")
+                ScreeningTimer.end(
+                  screeningId,
+                  outcome = "submitted",
+                  extraProps = screeningCompletionProps(),
+                )
                 setResult(
                   Activity.RESULT_OK,
                   Intent().apply {
@@ -594,15 +633,20 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
         retrieveQuestionnaireResponse()?.let { questionnaireResponse ->
           viewModel.isDraftSaved.observeForever {
             if (it){
+              PostHogAnalytics.capture(
+                PostHogAnalytics.Events.QUESTIONNAIRE_DRAFT_SAVED,
+                questionnaireAnalyticsProps(),
+              )
+              ScreeningTimer.end(
+                screeningId,
+                outcome = "draft_saved",
+                extraProps = screeningCompletionProps(),
+              )
               dialogue.dismiss()
               finish()
             }
           }
           viewModel.saveDraftQuestionnaire(questionnaireResponse)
-          PostHogAnalytics.capture(
-            PostHogAnalytics.Events.QUESTIONNAIRE_DRAFT_SAVED,
-            mapOf(PostHogAnalytics.Props.QUESTIONNAIRE_ID to questionnaireConfig.id),
-          )
         }
       }
     } else {
@@ -611,12 +655,64 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
         message =
           org.smartregister.fhircore.engine.R.string.questionnaire_alert_back_pressed_message,
         title = org.smartregister.fhircore.engine.R.string.questionnaire_alert_back_pressed_title,
-        confirmButtonListener = { finish() },
+        confirmButtonListener = {
+          ScreeningTimer.end(
+            screeningId,
+            outcome = "abandoned",
+            extraProps = screeningCompletionProps(),
+          )
+          finish()
+        },
         confirmButtonText =
           org.smartregister.fhircore.engine.R.string.questionnaire_alert_back_pressed_button_title,
       )
     }
   }
+
+  fun activeScreeningId(): String? = screeningId
+
+  private fun isFreshRegistrationQuestionnaire(): Boolean =
+    !questionnaireConfig.isReadOnly() &&
+      !questionnaireConfig.isEditable() &&
+      questionnaireKind() == "registration"
+
+  private fun questionnaireKind(): String {
+    val configText = "${questionnaireConfig.id} ${questionnaireConfig.title.orEmpty()}".lowercase()
+    return when {
+      configText.contains("follow") -> "followup"
+      configText.contains("registration") || configText.contains("register") -> "registration"
+      !questionnaireConfig.isReadOnly() &&
+        !questionnaireConfig.isEditable() &&
+        questionnaireConfig.resourceIdentifier.isNullOrBlank() -> "registration"
+      else -> "other"
+    }
+  }
+
+  private fun questionnaireAnalyticsProps(
+    vararg extras: Pair<String, Any?>,
+  ): Map<String, Any?> =
+    mutableMapOf<String, Any?>(
+        PostHogAnalytics.Props.QUESTIONNAIRE_ID to
+          (if (::questionnaireConfig.isInitialized) questionnaireConfig.id else "unknown"),
+        PostHogAnalytics.Props.QUESTIONNAIRE_KIND to
+          (if (::questionnaireConfig.isInitialized) questionnaireKind() else "other"),
+        PostHogAnalytics.Props.SCREENING_ID to screeningId,
+      )
+      .apply { extras.forEach { (key, value) -> put(key, value) } }
+
+  private fun screeningCompletionProps(
+    vararg extras: Pair<String, Any?>,
+  ): Map<String, Any?> =
+    mutableMapOf<String, Any?>(
+        PostHogAnalytics.Props.QUESTIONNAIRE_ID to
+          (if (::questionnaireConfig.isInitialized) questionnaireConfig.id else "unknown"),
+        PostHogAnalytics.Props.QUESTIONNAIRE_KIND to
+          (if (::questionnaireConfig.isInitialized) questionnaireKind() else "other"),
+      )
+      .apply {
+        putAll(DeviceMetrics.snapshot(this@QuestionnaireActivity))
+        extras.forEach { (key, value) -> put(key, value) }
+      }
 
   private suspend fun retrieveQuestionnaireResponse(): QuestionnaireResponse? =
     (supportFragmentManager.findFragmentByTag(QUESTIONNAIRE_FRAGMENT_TAG) as QuestionnaireFragment?)

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireActivity.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireActivity.kt
@@ -65,6 +65,7 @@ import org.smartregister.fhircore.engine.util.extension.showToast
 import org.smartregister.fhircore.quest.R
 import org.smartregister.fhircore.quest.databinding.QuestionnaireActivityBinding
 import org.smartregister.fhircore.quest.ui.register.patients.DocumentReferenceCaseType
+import org.smartregister.fhircore.quest.util.CASE_LEVEL_AI_RESULT_LINK_ID
 import org.smartregister.fhircore.quest.util.LocationUtils
 import org.smartregister.fhircore.quest.util.PermissionUtils
 import org.smartregister.fhircore.quest.util.REFER_CASE_URL
@@ -481,12 +482,14 @@ class QuestionnaireActivity : BaseMultiLanguageActivity() {
             val aiEnabled = FeatureFlagUtil.isAiInferenceEnabled(viewModel.fhirEngine)
 
             if (aiEnabled) {
-              var isSuspicious = viewModel.checkIfSuspicious(questionnaireResponse)
-              val suspiciousImages = viewModel.getSuspiciousImages(questionnaireResponse)
+              val aiSummary =
+                viewModel.summarizeAiInference(questionnaireResponse, questionnaire)
+              val isSuspicious = aiSummary.isSuspicious
+              val suspiciousImages = aiSummary.suspiciousImages
 
               val aiResultValue = if (isSuspicious) "suspicious" else "non-suspicious"
               val aiResultItem = QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
-                linkId = "case-level-ai-result"
+                linkId = CASE_LEVEL_AI_RESULT_LINK_ID
                 addAnswer(
                   QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
                     value = StringType(aiResultValue)

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
@@ -1078,6 +1078,11 @@ constructor(
     questionnaire: Questionnaire? = null,
   ): AiInferenceSummary {
     var isSuspicious = false
+    var imageCount = 0
+    var suspiciousImageCount = 0
+    var nonSuspiciousImageCount = 0
+    var lowConfidenceImageCount = 0
+    val confidenceValues = mutableListOf<Float>()
     val suspiciousImages = linkedSetOf<String>()
     val questionnaireItemsByLinkId =
       questionnaire?.let { mutableMapOf<String, Questionnaire.QuestionnaireItemComponent>() }
@@ -1137,7 +1142,21 @@ constructor(
           title?.let { suspiciousImages.add(it) }
         }
 
-        if (!result.isNullOrBlank() && !confidence.isNullOrBlank()) {
+        if (!result.isNullOrBlank()) {
+          imageCount += 1
+          if (result.isSuspiciousAiResult()) {
+            suspiciousImageCount += 1
+          } else {
+            nonSuspiciousImageCount += 1
+          }
+
+          confidence.toConfidenceFloat()?.let { confidenceValue ->
+            confidenceValues.add(confidenceValue)
+            if (confidenceValue < LOW_CONFIDENCE_THRESHOLD) {
+              lowConfidenceImageCount += 1
+            }
+          }
+
           siblings
             .firstOrNull { it.linkId == "${item.linkId}$AI_RESULT_SUFFIX" }
             ?.let { hiddenItem ->
@@ -1150,7 +1169,7 @@ constructor(
           if (answer.getExtensionByUrl(SUSPICIOUS_NON_SUSPICIOUS_URL) == null) {
             answer.addExtension(SUSPICIOUS_NON_SUSPICIOUS_URL, StringType(result))
           }
-          if (answer.getExtensionByUrl(CONFIDENCE_PERCENTAGE_URL) == null) {
+          if (!confidence.isNullOrBlank() && answer.getExtensionByUrl(CONFIDENCE_PERCENTAGE_URL) == null) {
             answer.addExtension(CONFIDENCE_PERCENTAGE_URL, StringType(confidence))
           }
           listOf(
@@ -1177,7 +1196,16 @@ constructor(
     } catch (e: Exception) {
       Timber.e(e, "Failed to summarize AI inference results")
     }
-    return AiInferenceSummary(isSuspicious, suspiciousImages.toList())
+    return AiInferenceSummary(
+      isSuspicious = isSuspicious,
+      suspiciousImages = suspiciousImages.toList(),
+      imageCount = imageCount,
+      suspiciousImageCount = suspiciousImageCount,
+      nonSuspiciousImageCount = nonSuspiciousImageCount,
+      lowConfidenceImageCount = lowConfidenceImageCount,
+      meanConfidence =
+        confidenceValues.takeIf { it.isNotEmpty() }?.average()?.toFloat() ?: 0f,
+    )
   }
 
   private fun collectQuestionnaireItems(
@@ -1212,6 +1240,13 @@ constructor(
   private fun String?.isSuspiciousAiResult(): Boolean =
     this?.substringBefore("|")?.trim()?.equals("suspicious", ignoreCase = true) == true
 
+  private fun String?.toConfidenceFloat(): Float? =
+    this
+      ?.substringBefore("|")
+      ?.replace("%", "")
+      ?.trim()
+      ?.toFloatOrNull()
+
   fun updateReferCase(qrId: String) {
     viewModelScope.launch(dispatcherProvider.io()) {
       try {
@@ -1228,7 +1263,16 @@ constructor(
   companion object {
     const val CONTAINED_LIST_TITLE = "GeneratedResourcesList"
     const val OUTPUT_PARAMETER_KEY = "OUTPUT"
+    private const val LOW_CONFIDENCE_THRESHOLD = 65f
   }
 }
 
-data class AiInferenceSummary(val isSuspicious: Boolean, val suspiciousImages: List<String>)
+data class AiInferenceSummary(
+  val isSuspicious: Boolean,
+  val suspiciousImages: List<String>,
+  val imageCount: Int = 0,
+  val suspiciousImageCount: Int = 0,
+  val nonSuspiciousImageCount: Int = 0,
+  val lowConfidenceImageCount: Int = 0,
+  val meanConfidence: Float = 0f,
+)

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.hl7.fhir.r4.context.IWorkerContext
+import org.hl7.fhir.r4.model.Attachment
 import org.hl7.fhir.r4.model.Base
 import org.hl7.fhir.r4.model.Basic
 import org.hl7.fhir.r4.model.Bundle
@@ -95,6 +96,13 @@ import org.smartregister.fhircore.engine.util.fhirpath.FhirPathDataExtractor
 import org.smartregister.fhircore.engine.util.helper.TransformSupportServices
 import org.smartregister.fhircore.quest.R
 
+import org.smartregister.fhircore.quest.ui.register.customui.MODEL6_CONFIDENCE_URL
+import org.smartregister.fhircore.quest.ui.register.customui.MODEL6_PREDICTION_URL
+import org.smartregister.fhircore.quest.ui.register.customui.MODEL8_CONFIDENCE_URL
+import org.smartregister.fhircore.quest.ui.register.customui.MODEL8_PREDICTION_URL
+import org.smartregister.fhircore.quest.ui.register.customui.MODEL82_CONFIDENCE_URL
+import org.smartregister.fhircore.quest.ui.register.customui.MODEL82_PREDICTION_URL
+import org.smartregister.fhircore.quest.util.AI_RESULT_SUFFIX
 import org.smartregister.fhircore.quest.util.CONFIDENCE_PERCENTAGE_URL
 import org.smartregister.fhircore.quest.util.DraftsUtils.getAllDraftsJsonFromSharedPreferences
 import org.smartregister.fhircore.quest.util.DraftsUtils.parseDraftResponses
@@ -1057,123 +1065,145 @@ constructor(
     _questionnaireProgressStateLiveData.postValue(questionnaireState)
   }
 
-  fun checkIfSuspicious(questionnaireResponse: QuestionnaireResponse): Boolean {
+  /**
+   * Walks the [questionnaireResponse] tree, materializes the per-image AI inference into the
+   * sibling `<linkId>$AI_RESULT_SUFFIX` hidden item, and returns a case-level summary.
+   *
+   * The contract is structural rather than path-based: any answer carrying the AI extensions is
+   * treated as an inference-bearing answer, and any item with the [AI_RESULT_SUFFIX] suffix is its
+   * sibling carrier. This avoids hardcoding `screening-group` / `patient-screening-image-group`.
+   */
+  fun summarizeAiInference(
+    questionnaireResponse: QuestionnaireResponse,
+    questionnaire: Questionnaire? = null,
+  ): AiInferenceSummary {
     var isSuspicious = false
+    val suspiciousImages = linkedSetOf<String>()
+    val questionnaireItemsByLinkId =
+      questionnaire?.let { mutableMapOf<String, Questionnaire.QuestionnaireItemComponent>() }
+    questionnaire?.item?.let { collectQuestionnaireItems(it, questionnaireItemsByLinkId!!) }
     try {
-      Timber.d("=== Starting to set AI results in hidden items ===")
-      for (item in questionnaireResponse.item) {
-        if (item.linkId == "screening-group") {
-          Timber.d("Found screening-group for AI result processing")
-          item.item.forEach { group ->
-            if (group.linkId == "patient-screening-image-group") {
-              Timber.d("Found patient-screening-image-group, total items: ${group.item.size}")
-              group.item.forEach imageItems@{ imageOrHiddenItem ->
-                if (imageOrHiddenItem.linkId.endsWith("-ai-result")) {
-                  val hiddenResult = imageOrHiddenItem.answer.firstOrNull()?.value.asPrimitiveString()
-                  if (hiddenResult.isSuspiciousAiResult()) {
-                    isSuspicious = true
-                  }
-                  Timber.d("Read AI result item: ${imageOrHiddenItem.linkId}")
-                  return@imageItems
-                }
+      Timber.d("=== AI inference summary: walking QR ===")
+      forEachQrItemWithSiblings(questionnaireResponse.item) { item, siblings ->
+        if (item.linkId.endsWith(AI_RESULT_SUFFIX)) {
+          val hiddenValue = item.answer.firstOrNull()?.value.asPrimitiveString()
+          Timber.d("AI hidden item linkId=${item.linkId} value=$hiddenValue")
+          if (hiddenValue.isSuspiciousAiResult()) {
+            isSuspicious = true
+            val originalLinkId = item.linkId.removeSuffix(AI_RESULT_SUFFIX)
+            siblings
+              .firstOrNull { it.linkId == originalLinkId }
+              ?.answer
+              ?.firstOrNull()
+              ?.let { it.value as? Attachment }
+              ?.title
+              ?.let { suspiciousImages.add(it) }
+          }
+          return@forEachQrItemWithSiblings
+        }
 
-                try {
-                  Timber.d("Processing item: ${imageOrHiddenItem.linkId}, has answers: ${imageOrHiddenItem.answer.isNotEmpty()}")
-                  if (imageOrHiddenItem.answer.isNotEmpty()) {
-                    val firstAnswer = imageOrHiddenItem.answer.firstOrNull()
-                    Timber.d("First answer exists: ${firstAnswer != null}, has extensions: ${firstAnswer?.hasExtension()}, extension count: ${firstAnswer?.extension?.size}")
+        val answer = item.answer.firstOrNull() ?: return@forEachQrItemWithSiblings
 
-                    if (firstAnswer != null && firstAnswer.hasExtension()) {
-                      val resultExtension = firstAnswer.getExtensionByUrl(SUSPICIOUS_NON_SUSPICIOUS_URL)
-                      val confidenceExtension = firstAnswer.getExtensionByUrl(CONFIDENCE_PERCENTAGE_URL)
+        // Only attachment-typed answers carry AI extensions; skip Coding/String/etc. items so
+        // HAPI's typed accessors don't throw.
+        if (answer.value !is Attachment) return@forEachQrItemWithSiblings
 
-                      Timber.d("Result extension: ${resultExtension != null}, Confidence extension: ${confidenceExtension != null}")
+        // The combined AI extension is written by CustomAttachmentViewHolderFactory onto both
+        // the QR answer AND the Questionnaire item. SDC strips the QR answer's extensions on
+        // submit, so the Questionnaire item is the surviving source of truth.
+        val qItem = questionnaireItemsByLinkId?.get(item.linkId)
 
-                      val result = resultExtension?.value.asPrimitiveString()
-                      val confidence = confidenceExtension?.value.asPrimitiveString()
+        fun extString(url: String): String? =
+          answer.getExtensionByUrl(url)?.value.asPrimitiveString()
+            ?: qItem?.getExtensionByUrl(url)?.value.asPrimitiveString()
 
-                      Timber.d("Result value: $result, Confidence value: $confidence")
+        val result = extString(SUSPICIOUS_NON_SUSPICIOUS_URL)
+        val confidence = extString(CONFIDENCE_PERCENTAGE_URL)
 
-                      if (result.isSuspiciousAiResult()) {
-                        isSuspicious = true
-                      }
+        val attachment = answer.value as? Attachment
+        val title = attachment?.title
+        Timber.d(
+          "AI walk image item linkId=${item.linkId} title=$title " +
+            "qrAnswerExtCount=${answer.extension.size} " +
+            "qItemExtCount=${qItem?.extension?.size ?: -1} " +
+            "combined=$result|$confidence " +
+            "v6=${extString(MODEL6_PREDICTION_URL)}|${extString(MODEL6_CONFIDENCE_URL)} " +
+            "v8=${extString(MODEL8_PREDICTION_URL)}|${extString(MODEL8_CONFIDENCE_URL)} " +
+            "v82=${extString(MODEL82_PREDICTION_URL)}|${extString(MODEL82_CONFIDENCE_URL)}",
+        )
 
-                      if (!result.isNullOrBlank() && !confidence.isNullOrBlank()) {
-                        val hiddenLinkId = "${imageOrHiddenItem.linkId}-ai-result"
-                        val hiddenItem = group.item.find { it.linkId == hiddenLinkId }
+        if (result.isSuspiciousAiResult()) {
+          isSuspicious = true
+          title?.let { suspiciousImages.add(it) }
+        }
 
-                        Timber.d("Looking for hidden item: $hiddenLinkId, found: ${hiddenItem != null}")
+        if (!result.isNullOrBlank() && !confidence.isNullOrBlank()) {
+          siblings
+            .firstOrNull { it.linkId == "${item.linkId}$AI_RESULT_SUFFIX" }
+            ?.let { hiddenItem ->
+              if (hiddenItem.answer.isEmpty()) hiddenItem.addAnswer()
+              hiddenItem.answer[0].value = StringType("$result|$confidence")
+            }
 
-                        if (hiddenItem != null) {
-                          Timber.d("BEFORE: Hidden item $hiddenLinkId has ${hiddenItem.answer.size} answers")
-
-                          // Set or update the answer
-                          if (hiddenItem.answer.isEmpty()) {
-                            Timber.d("Adding new answer to hidden item")
-                            hiddenItem.addAnswer()
-                          }
-
-                          Timber.d("Setting value on hidden item answer")
-                          hiddenItem.answer[0].value = StringType("$result|$confidence")
-
-                          Timber.d("AFTER: Successfully set AI result for $hiddenLinkId: $result|$confidence")
-                        } else {
-                          Timber.w("Hidden item not found for linkId: $hiddenLinkId")
-                        }
-                      }
-                    }
-                  }
-                } catch (e: Exception) {
-                  Timber.e(e, "!!! EXCEPTION processing image item: ${imageOrHiddenItem.linkId}")
+          // Mirror onto the QR answer so downstream readers (e.g. StructureMap copy rules) see the
+          // values regardless of whether the SDC-stripped answer extensions are present.
+          if (answer.getExtensionByUrl(SUSPICIOUS_NON_SUSPICIOUS_URL) == null) {
+            answer.addExtension(SUSPICIOUS_NON_SUSPICIOUS_URL, StringType(result))
+          }
+          if (answer.getExtensionByUrl(CONFIDENCE_PERCENTAGE_URL) == null) {
+            answer.addExtension(CONFIDENCE_PERCENTAGE_URL, StringType(confidence))
+          }
+          listOf(
+              MODEL6_PREDICTION_URL,
+              MODEL6_CONFIDENCE_URL,
+              MODEL8_PREDICTION_URL,
+              MODEL8_CONFIDENCE_URL,
+              MODEL82_PREDICTION_URL,
+              MODEL82_CONFIDENCE_URL,
+            )
+            .forEach { url ->
+              if (answer.getExtensionByUrl(url) == null) {
+                qItem?.getExtensionByUrl(url)?.value?.asPrimitiveString()?.let {
+                  answer.addExtension(url, StringType(it))
                 }
               }
             }
-          }
         }
       }
-      Timber.d("=== Finished setting AI results in hidden items ===")
+      Timber.d(
+        "=== AI inference summary done: isSuspicious=$isSuspicious " +
+          "suspiciousImages=$suspiciousImages ===",
+      )
     } catch (e: Exception) {
-      Timber.e(e, "!!! EXCEPTION in outer try-catch for AI result processing")
-      throw e
+      Timber.e(e, "Failed to summarize AI inference results")
     }
-    return isSuspicious
+    return AiInferenceSummary(isSuspicious, suspiciousImages.toList())
   }
 
-  fun getSuspiciousImages(questionnaireResponse: QuestionnaireResponse): List<String> {
-    val suspiciousImages = linkedSetOf<String>()
-    try {
-      for (item in questionnaireResponse.item) {
-        if (item.linkId == "screening-group") {
-          item.item.forEach { group ->
-            if (group.linkId == "patient-screening-image-group") {
-              group.item.forEach imageItems@{ item ->
-                if (item.linkId.endsWith("-ai-result")) {
-                  val answer = item.answer.firstOrNull()?.value.asPrimitiveString()
-                  if (answer.isSuspiciousAiResult()) {
-                    val originalLinkId = item.linkId.removeSuffix("-ai-result")
-                    val originalItem = group.item.find { it.linkId == originalLinkId }
-                    originalItem?.answer?.firstOrNull()?.valueAttachment?.title?.let {
-                      suspiciousImages.add(it)
-                    }
-                  }
-                  return@imageItems
-                }
-
-                val answer = item.answer.firstOrNull() ?: return@imageItems
-                val result =
-                  answer.getExtensionByUrl(SUSPICIOUS_NON_SUSPICIOUS_URL)?.value.asPrimitiveString()
-                if (result.isSuspiciousAiResult()) {
-                  answer.valueAttachment?.title?.let { suspiciousImages.add(it) }
-                }
-              }
-            }
-          }
-        }
-      }
-    } catch (e: Exception) {
-      Timber.e(e)
+  private fun collectQuestionnaireItems(
+    items: List<Questionnaire.QuestionnaireItemComponent>,
+    out: MutableMap<String, Questionnaire.QuestionnaireItemComponent>,
+  ) {
+    items.forEach { qItem ->
+      qItem.linkId?.let { out[it] = qItem }
+      if (qItem.item.isNotEmpty()) collectQuestionnaireItems(qItem.item, out)
     }
-    return suspiciousImages.toList()
+  }
+
+  private fun forEachQrItemWithSiblings(
+    items: List<QuestionnaireResponse.QuestionnaireResponseItemComponent>,
+    action: (
+      QuestionnaireResponse.QuestionnaireResponseItemComponent,
+      List<QuestionnaireResponse.QuestionnaireResponseItemComponent>,
+    ) -> Unit,
+  ) {
+    items.forEach { item ->
+      action(item, items)
+      if (item.item.isNotEmpty()) forEachQrItemWithSiblings(item.item, action)
+      item.answer.forEach { answer ->
+        if (answer.item.isNotEmpty()) forEachQrItemWithSiblings(answer.item, action)
+      }
+    }
   }
 
   private fun Base?.asPrimitiveString(): String? =
@@ -1200,3 +1230,5 @@ constructor(
     const val OUTPUT_PARAMETER_KEY = "OUTPUT"
   }
 }
+
+data class AiInferenceSummary(val isSuspicious: Boolean, val suspiciousImages: List<String>)

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
@@ -1067,11 +1067,14 @@ constructor(
           item.item.forEach { group ->
             if (group.linkId == "patient-screening-image-group") {
               Timber.d("Found patient-screening-image-group, total items: ${group.item.size}")
-              group.item.forEach { imageOrHiddenItem ->
-                // Skip items that are AI result items (ending with -ai-result)
+              group.item.forEach imageItems@{ imageOrHiddenItem ->
                 if (imageOrHiddenItem.linkId.endsWith("-ai-result")) {
-                  Timber.d("Skipping AI result item: ${imageOrHiddenItem.linkId}")
-                  return@forEach
+                  val hiddenResult = imageOrHiddenItem.answer.firstOrNull()?.value.asPrimitiveString()
+                  if (hiddenResult.isSuspiciousAiResult()) {
+                    isSuspicious = true
+                  }
+                  Timber.d("Read AI result item: ${imageOrHiddenItem.linkId}")
+                  return@imageItems
                 }
 
                 try {
@@ -1080,48 +1083,42 @@ constructor(
                     val firstAnswer = imageOrHiddenItem.answer.firstOrNull()
                     Timber.d("First answer exists: ${firstAnswer != null}, has extensions: ${firstAnswer?.hasExtension()}, extension count: ${firstAnswer?.extension?.size}")
 
-                    if (firstAnswer != null && firstAnswer.hasExtension() && firstAnswer.extension.size > 1) {
+                    if (firstAnswer != null && firstAnswer.hasExtension()) {
                       val resultExtension = firstAnswer.getExtensionByUrl(SUSPICIOUS_NON_SUSPICIOUS_URL)
                       val confidenceExtension = firstAnswer.getExtensionByUrl(CONFIDENCE_PERCENTAGE_URL)
 
                       Timber.d("Result extension: ${resultExtension != null}, Confidence extension: ${confidenceExtension != null}")
 
-                      if (resultExtension != null && confidenceExtension != null) {
-                        val result = resultExtension.value
-                        val confidence = confidenceExtension.value
+                      val result = resultExtension?.value.asPrimitiveString()
+                      val confidence = confidenceExtension?.value.asPrimitiveString()
 
-                        Timber.d("Result value: $result, Confidence value: $confidence")
+                      Timber.d("Result value: $result, Confidence value: $confidence")
 
-                        if (result != null && confidence != null) {
-                          val hiddenLinkId = "${imageOrHiddenItem.linkId}-ai-result"
-                          val hiddenItem = group.item.find { it.linkId == hiddenLinkId }
+                      if (result.isSuspiciousAiResult()) {
+                        isSuspicious = true
+                      }
 
-                          Timber.d("Looking for hidden item: $hiddenLinkId, found: ${hiddenItem != null}")
+                      if (!result.isNullOrBlank() && !confidence.isNullOrBlank()) {
+                        val hiddenLinkId = "${imageOrHiddenItem.linkId}-ai-result"
+                        val hiddenItem = group.item.find { it.linkId == hiddenLinkId }
 
-                          if (hiddenItem != null) {
-                            Timber.d("BEFORE: Hidden item $hiddenLinkId has ${hiddenItem.answer.size} answers")
+                        Timber.d("Looking for hidden item: $hiddenLinkId, found: ${hiddenItem != null}")
 
-                            // Set or update the answer
-                            if (hiddenItem.answer.isEmpty()) {
-                              Timber.d("Adding new answer to hidden item")
-                              hiddenItem.addAnswer()
-                            }
+                        if (hiddenItem != null) {
+                          Timber.d("BEFORE: Hidden item $hiddenLinkId has ${hiddenItem.answer.size} answers")
 
-                            // Update isSuspicious whenever a "suspicious" image result is found,
-                            // not only on first-time hidden-item population. Otherwise re-running
-                            // checkIfSuspicious on a draft (where hiddenItem already has an answer)
-                            // returns false even when an image is suspicious — i.e. a false negative.
-                            if (isSuspicious.not()) {
-                              isSuspicious = result.toString().equals("suspicious", ignoreCase = true)
-                            }
-
-                            Timber.d("Setting value on hidden item answer")
-                            hiddenItem.answer[0].value = StringType("$result|$confidence")
-
-                            Timber.d("AFTER: Successfully set AI result for $hiddenLinkId: $result|$confidence")
-                          } else {
-                            Timber.w("Hidden item not found for linkId: $hiddenLinkId")
+                          // Set or update the answer
+                          if (hiddenItem.answer.isEmpty()) {
+                            Timber.d("Adding new answer to hidden item")
+                            hiddenItem.addAnswer()
                           }
+
+                          Timber.d("Setting value on hidden item answer")
+                          hiddenItem.answer[0].value = StringType("$result|$confidence")
+
+                          Timber.d("AFTER: Successfully set AI result for $hiddenLinkId: $result|$confidence")
+                        } else {
+                          Timber.w("Hidden item not found for linkId: $hiddenLinkId")
                         }
                       }
                     }
@@ -1143,24 +1140,30 @@ constructor(
   }
 
   fun getSuspiciousImages(questionnaireResponse: QuestionnaireResponse): List<String> {
-    val suspiciousImages = mutableListOf<String>()
+    val suspiciousImages = linkedSetOf<String>()
     try {
       for (item in questionnaireResponse.item) {
         if (item.linkId == "screening-group") {
           item.item.forEach { group ->
             if (group.linkId == "patient-screening-image-group") {
-              group.item.forEach { item ->
+              group.item.forEach imageItems@{ item ->
                 if (item.linkId.endsWith("-ai-result")) {
-                  if (item.answer.isNotEmpty()) {
-                    val answer = item.answer[0].value.toString()
-                    if (answer.startsWith("suspicious", ignoreCase = true)) {
-                      val originalLinkId = item.linkId.removeSuffix("-ai-result")
-                      val originalItem = group.item.find { it.linkId == originalLinkId }
-                      originalItem?.answer?.firstOrNull()?.valueAttachment?.title?.let {
-                        suspiciousImages.add(it)
-                      }
+                  val answer = item.answer.firstOrNull()?.value.asPrimitiveString()
+                  if (answer.isSuspiciousAiResult()) {
+                    val originalLinkId = item.linkId.removeSuffix("-ai-result")
+                    val originalItem = group.item.find { it.linkId == originalLinkId }
+                    originalItem?.answer?.firstOrNull()?.valueAttachment?.title?.let {
+                      suspiciousImages.add(it)
                     }
                   }
+                  return@imageItems
+                }
+
+                val answer = item.answer.firstOrNull() ?: return@imageItems
+                val result =
+                  answer.getExtensionByUrl(SUSPICIOUS_NON_SUSPICIOUS_URL)?.value.asPrimitiveString()
+                if (result.isSuspiciousAiResult()) {
+                  answer.valueAttachment?.title?.let { suspiciousImages.add(it) }
                 }
               }
             }
@@ -1170,8 +1173,14 @@ constructor(
     } catch (e: Exception) {
       Timber.e(e)
     }
-    return suspiciousImages
+    return suspiciousImages.toList()
   }
+
+  private fun Base?.asPrimitiveString(): String? =
+    this?.primitiveValue()?.takeIf { it.isNotBlank() } ?: this?.toString()?.takeIf { it.isNotBlank() }
+
+  private fun String?.isSuspiciousAiResult(): Boolean =
+    this?.substringBefore("|")?.trim()?.equals("suspicious", ignoreCase = true) == true
 
   fun updateReferCase(qrId: String) {
     viewModelScope.launch(dispatcherProvider.io()) {

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModel.kt
@@ -212,7 +212,7 @@ constructor(
         // Set barcode to the configured linkId default: "patient-barcode"
         if (!questionnaireConfig.resourceIdentifier.isNullOrEmpty()) {
           (questionnaireConfig.barcodeLinkId
-              ?: questionnaireConfig.linkIds?.firstOrNull { it.type == LinkIdType.BARCODE }?.linkId)
+            ?: questionnaireConfig.linkIds?.firstOrNull { it.type == LinkIdType.BARCODE }?.linkId)
             ?.let { barcodeLinkId ->
               find(barcodeLinkId)?.apply {
                 initial =
@@ -339,14 +339,7 @@ constructor(
       onSuccessfulSubmission(idTypes, currentQuestionnaireResponse)
 
       // Trigger one time sync after question submission
-      if (org.smartregister.fhircore.engine.sync.AppSyncWorker.mutex.isLocked) {
-        context.showToast(
-          context.getString(R.string.sync_in_progress),
-          android.widget.Toast.LENGTH_SHORT
-        )
-      } else {
-        syncBroadcaster.runOneTimeSync()
-      }
+      syncBroadcaster.runOneTimeSync()
     }
   }
 
@@ -388,9 +381,9 @@ constructor(
         applyResourceMetadata(questionnaireConfig, questionnaireResponse, context)
         if (
           questionnaireResponse.subject.reference.isNullOrEmpty() &&
-            subjectType != null &&
-            resourceType == subjectType &&
-            logicalId.isNotEmpty()
+          subjectType != null &&
+          resourceType == subjectType &&
+          logicalId.isNotEmpty()
         ) {
           questionnaireResponse.subject = this.logicalId.asReference(subjectType)
         }
@@ -399,9 +392,9 @@ constructor(
             this.id = questionnaireResponse.subject.extractId()
           } else if (
             extractedResourceUniquePropertyExpressionsMap.containsKey(resourceType) &&
-              previouslyExtractedResources.containsKey(
-                resourceType,
-              )
+            previouslyExtractedResources.containsKey(
+              resourceType,
+            )
           ) {
             val fhirPathExpression =
               extractedResourceUniquePropertyExpressionsMap
@@ -423,7 +416,7 @@ constructor(
                     expression = fhirPathExpression,
                   )
                 extractedValue.isNotEmpty() &&
-                  extractedValue.equals(currentResourceIdentifier, true)
+                        extractedValue.equals(currentResourceIdentifier, true)
               }
 
             // Found match use the id on current resource; override identifiers for RelatedPerson
@@ -468,7 +461,7 @@ constructor(
 
     if (
       !questionnaireResponse.subject.reference.isNullOrEmpty() &&
-        questionnaireConfig.saveQuestionnaireResponse
+      questionnaireConfig.saveQuestionnaireResponse
     ) {
       // Set the Group's Related Entity Location meta tag on QuestionnaireResponse then save.
       questionnaireResponse.applyRelatedEntityLocationMetaTag(
@@ -491,8 +484,8 @@ constructor(
           Pair(subjectType, questionnaireConfig.resourceIdentifier!!)
         }
         !questionnaireConfig.groupResource?.groupIdentifier.isNullOrEmpty() &&
-          questionnaireConfig.groupResource?.removeGroup != true &&
-          questionnaireConfig.groupResource?.removeMember != true -> {
+                questionnaireConfig.groupResource?.removeGroup != true &&
+                questionnaireConfig.groupResource?.removeMember != true -> {
           Pair(ResourceType.Group, questionnaireConfig.groupResource!!.groupIdentifier)
         }
         else -> null
@@ -518,14 +511,14 @@ constructor(
     val referencedResources = mutableMapOf<ResourceType, MutableList<Resource>>()
     if (
       questionnaireConfig.isEditable() &&
-        !questionnaireConfig.resourceIdentifier.isNullOrEmpty() &&
-        subjectType != null
+      !questionnaireConfig.resourceIdentifier.isNullOrEmpty() &&
+      subjectType != null
     ) {
       searchLatestQuestionnaireResponse(
-          resourceId = questionnaireConfig.resourceIdentifier!!,
-          resourceType = questionnaireConfig.resourceType ?: subjectType,
-          questionnaireId = questionnaire.logicalId,
-        )
+        resourceId = questionnaireConfig.resourceIdentifier!!,
+        resourceType = questionnaireConfig.resourceType ?: subjectType,
+        questionnaireId = questionnaire.logicalId,
+      )
         ?.contained
         ?.asSequence()
         ?.filterIsInstance<ListResource>()
@@ -775,11 +768,11 @@ constructor(
     }
 
     return QuestionnaireResponseValidator.validateQuestionnaireResponse(
-        questionnaire = Questionnaire().apply { item = validQuestionnaireItems },
-        questionnaireResponse =
-          QuestionnaireResponse().apply { item = validQuestionnaireResponseItems },
-        context = context,
-      )
+      questionnaire = Questionnaire().apply { item = validQuestionnaireItems },
+      questionnaireResponse =
+        QuestionnaireResponse().apply { item = validQuestionnaireResponseItems },
+      context = context,
+    )
       .values
       .flatten()
       .all { it is Valid || it is NotValidated }
@@ -822,10 +815,10 @@ constructor(
 
           result.parameter.mapNotNull { cqlResultParameterComponent ->
             (cqlResultParameterComponent.value ?: cqlResultParameterComponent.resource)?.let {
-              resultParameterResource ->
+                resultParameterResource ->
               if (
                 cqlResultParameterComponent.name.equals(OUTPUT_PARAMETER_KEY) &&
-                  resultParameterResource.isResource
+                resultParameterResource.isResource
               ) {
                 defaultRepository.create(true, resultParameterResource as Resource)
               }
@@ -833,10 +826,10 @@ constructor(
               if (BuildConfig.DEBUG) {
                 Timber.d(
                   "CQL :: Param found: ${cqlResultParameterComponent.name} with value: ${
-                                        getStringRepresentation(
-                                            resultParameterResource,
-                                        )
-                                    }",
+                    getStringRepresentation(
+                      resultParameterResource,
+                    )
+                  }",
                 )
               }
             }
@@ -880,13 +873,13 @@ constructor(
     // Load the group from the database to get the updated Resource always.
     val group =
       groupIdentifier?.extractLogicalIdUuid()?.let { loadResource(ResourceType.Group, it) }
-        as Group?
+              as Group?
 
     if (
       group != null &&
-        resource is RelatedPerson &&
-        !resource.relationshipFirstRep.codingFirstRep.code.isNullOrEmpty() &&
-        resource.relationshipFirstRep.codingFirstRep.code == managingEntityRelationshipCode
+      resource is RelatedPerson &&
+      !resource.relationshipFirstRep.codingFirstRep.code.isNullOrEmpty() &&
+      resource.relationshipFirstRep.codingFirstRep.code == managingEntityRelationshipCode
     ) {
       defaultRepository.addOrUpdate(
         resource = group.apply { managingEntity = resource.asReference() },
@@ -907,7 +900,7 @@ constructor(
     // Load the Group resource from the database to get the updated one
     val group =
       groupIdentifier?.extractLogicalIdUuid()?.let { loadResource(ResourceType.Group, it) }
-        as Group? ?: return
+              as Group? ?: return
 
     val reference = resource.asReference()
     val member = group.member.find { it.entity.reference.equals(reference.reference, true) }
@@ -955,8 +948,8 @@ constructor(
 
     if (
       questionnaireConfig.removeResource == true &&
-        questionnaireConfig.resourceType != null &&
-        !questionnaireConfig.resourceIdentifier.isNullOrEmpty()
+      questionnaireConfig.resourceType != null &&
+      !questionnaireConfig.resourceIdentifier.isNullOrEmpty()
     ) {
       viewModelScope.launch {
         defaultRepository.delete(
@@ -1039,8 +1032,8 @@ constructor(
     return actionParameters
       .filter {
         it.paramType == ActionParameterType.QUESTIONNAIRE_RESPONSE_POPULATION_RESOURCE &&
-          it.resourceType != null &&
-          it.value.isNotEmpty()
+                it.resourceType != null &&
+                it.value.isNotEmpty()
       }
       .mapNotNull {
         try {
@@ -1112,9 +1105,14 @@ constructor(
                             if (hiddenItem.answer.isEmpty()) {
                               Timber.d("Adding new answer to hidden item")
                               hiddenItem.addAnswer()
-                              if(isSuspicious.not()){
-                                isSuspicious = result.toString().equals("suspicious", ignoreCase = true)
-                              }
+                            }
+
+                            // Update isSuspicious whenever a "suspicious" image result is found,
+                            // not only on first-time hidden-item population. Otherwise re-running
+                            // checkIfSuspicious on a draft (where hiddenItem already has an answer)
+                            // returns false even when an image is suspicious — i.e. a false negative.
+                            if (isSuspicious.not()) {
+                              isSuspicious = result.toString().equals("suspicious", ignoreCase = true)
                             }
 
                             Timber.d("Setting value on hidden item answer")

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/register/customui/CustomAttachmentViewHolderFactory.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/register/customui/CustomAttachmentViewHolderFactory.kt
@@ -368,6 +368,7 @@ internal object CustomAttachmentViewHolderFactory :
                         result.getString(CameraxLauncherFragment.CAMERA_MODEL82_PREDICTION_KEY)
                     val model82Confidence =
                         result.getString(CameraxLauncherFragment.CAMERA_MODEL82_CONFIDENCE_KEY)
+                    val hasAiInferenceResult = isAiInferenceEnabled() && !predictionResult.isNullOrBlank()
 
                     if (!fileAbsolutePath.isNullOrEmpty()) {
                         try {
@@ -405,7 +406,7 @@ internal object CustomAttachmentViewHolderFactory :
                                 attachmentMimeTypeWithSubType
                             ).apply {
                                 // Add AI Model results to DocumentReference
-                                if (isAiInferenceEnabled()) {
+                                if (hasAiInferenceResult) {
                                     if (!model6Prediction.isNullOrEmpty()) {
                                         addExtension(
                                             MODEL6_PREDICTION_URL,
@@ -444,14 +445,14 @@ internal object CustomAttachmentViewHolderFactory :
                             val answer =
                                 QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent()
                                     .apply {
-                                        if (isAiInferenceEnabled()) {
+                                        if (hasAiInferenceResult) {
                                             addExtension(
                                                 SUSPICIOUS_NON_SUSPICIOUS_URL,
                                                 StringType(predictionResult.orEmpty())
                                             )
                                             addExtension(
                                                 CONFIDENCE_PERCENTAGE_URL,
-                                                StringType(confidence)
+                                                StringType(confidence.orEmpty())
                                             )
 
                                             if (!model6Prediction.isNullOrEmpty()) {
@@ -497,17 +498,17 @@ internal object CustomAttachmentViewHolderFactory :
                                             }
                                     }
 
-                            if (isAiInferenceEnabled()) {
+                            if (hasAiInferenceResult) {
                                 //Suspicious/NonSuspicious
                                 questionnaireItem.addExtension(
                                     SUSPICIOUS_NON_SUSPICIOUS_URL,
-                                    StringType(predictionResult)
+                                    StringType(predictionResult.orEmpty())
                                 )
 
                                 //Confidence percentage
                                 questionnaireItem.addExtension(
                                     CONFIDENCE_PERCENTAGE_URL,
-                                    StringType(confidence)
+                                    StringType(confidence.orEmpty())
                                 )
 
                                 // Add individual model results to questionnaire item
@@ -552,7 +553,7 @@ internal object CustomAttachmentViewHolderFactory :
                                 divider.visibility = View.VISIBLE
                                 displayPreview(
                                     attachmentType = attachmentMimeType,
-                                    attachmentTitle = if (predictionResult.isNullOrEmpty() || !isAiInferenceEnabled()) capturedFile.name else "RESULT : $predictionResult",
+                                    attachmentTitle = if (hasAiInferenceResult) "RESULT : $predictionResult" else capturedFile.name,
                                     attachmentUri = attachmentUri,
                                     questionnaireItem = questionnaireItem
                                 )
@@ -562,7 +563,7 @@ internal object CustomAttachmentViewHolderFactory :
                             }
 
                         } catch (e: Exception) {
-                            Timber.i("TAG", "error --> " + e.printStackTrace())
+                            Timber.e(e, "error --> %s", e.printStackTrace())
                             e.printStackTrace()
                         }
 
@@ -1230,6 +1231,3 @@ internal const val MODEL82_CONFIDENCE_URL =
 
 internal const val CASE_PREDICTION_RESULT_URL =
     "http://smartregister.org/ai-model-result/case-prediction-result"
-
-
-            

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/register/customui/CustomAttachmentViewHolderFactory.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/register/customui/CustomAttachmentViewHolderFactory.kt
@@ -772,22 +772,22 @@ internal object CustomAttachmentViewHolderFactory :
                     stringBuilder.append("\n")
                 }
 
-                if (!m6Pred.isNullOrEmpty()) {
-                    stringBuilder.append("M6: $m6Pred")
-                    if (!m6Conf.isNullOrEmpty()) stringBuilder.append(" ($m6Conf%)")
-                    stringBuilder.append("\n")
-                }
-
-                if (!m8Pred.isNullOrEmpty()) {
-                    stringBuilder.append("M8: $m8Pred")
-                    if (!m8Conf.isNullOrEmpty()) stringBuilder.append(" ($m8Conf%)")
-                    stringBuilder.append("\n")
-                }
-
-                if (!m82Pred.isNullOrEmpty()) {
-                    stringBuilder.append("M82: $m82Pred")
-                    if (!m82Conf.isNullOrEmpty()) stringBuilder.append(" ($m82Conf%)")
-                }
+//                if (!m6Pred.isNullOrEmpty()) {
+//                    stringBuilder.append("M6: $m6Pred")
+//                    if (!m6Conf.isNullOrEmpty()) stringBuilder.append(" ($m6Conf%)")
+//                    stringBuilder.append("\n")
+//                }
+//
+//                if (!m8Pred.isNullOrEmpty()) {
+//                    stringBuilder.append("M8: $m8Pred")
+//                    if (!m8Conf.isNullOrEmpty()) stringBuilder.append(" ($m8Conf%)")
+//                    stringBuilder.append("\n")
+//                }
+//
+//                if (!m82Pred.isNullOrEmpty()) {
+//                    stringBuilder.append("M82: $m82Pred")
+//                    if (!m82Conf.isNullOrEmpty()) stringBuilder.append(" ($m82Conf%)")
+//                }
                 val finalString = stringBuilder.toString().trim()
                 if (finalString.isNotEmpty()) {
                     photoResult.text = finalString

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/register/customui/CustomAttachmentViewHolderFactory.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/register/customui/CustomAttachmentViewHolderFactory.kt
@@ -63,6 +63,7 @@ import org.smartregister.fhircore.engine.util.extension.logicalId
 import org.smartregister.fhircore.quest.BuildConfig
 import org.smartregister.fhircore.quest.R
 import org.smartregister.fhircore.quest.camerax.CameraxLauncherFragment
+import org.smartregister.fhircore.quest.ui.questionnaire.QuestionnaireActivity
 import org.smartregister.fhircore.quest.util.CONFIDENCE_PERCENTAGE_URL
 import org.smartregister.fhircore.quest.util.SUSPICIOUS_NON_SUSPICIOUS_URL
 import timber.log.Timber
@@ -572,7 +573,7 @@ internal object CustomAttachmentViewHolderFactory :
                     }
                 }
 
-                CameraxLauncherFragment.newInstance()
+                CameraxLauncherFragment.newInstance((context as? QuestionnaireActivity)?.activeScreeningId())
                     .show(
                         context.supportFragmentManager,
                         CustomAttachmentViewHolderFactory::class.java.simpleName
@@ -739,39 +740,18 @@ internal object CustomAttachmentViewHolderFactory :
                     Glide.with(context).load(uri).into(photoThumbnail)
                     this.photoTitle.text = photoTitle
 
-//                    val result = questionnaireItem?.getExtensionString(SUSPICIOUS_NON_SUSPICIOUS_URL)
-//
-//                    if (result?.isNotEmpty() == true) {
-//                        photoResult.text = result
-//                        photoResult.visibility = View.VISIBLE
-//                        // Hide separate confidence view as it is merged into the main text
-//                        photoConfidence.visibility = View.GONE
-//                    } else {
-//                        photoResult.visibility = View.GONE
-//                        photoConfidence.visibility = View.GONE
-//                    }
-                }catch (exc: Exception) {
+                    val result = questionnaireItem?.getExtensionString(SUSPICIOUS_NON_SUSPICIOUS_URL)
+                    val confidence = questionnaireItem?.getExtensionString(CONFIDENCE_PERCENTAGE_URL)
+                    val m6Pred = questionnaireItem?.getExtensionString(MODEL6_PREDICTION_URL)
+                    val m6Conf = questionnaireItem?.getExtensionString(MODEL6_CONFIDENCE_URL)
+                    val m8Pred = questionnaireItem?.getExtensionString(MODEL8_PREDICTION_URL)
+                    val m8Conf = questionnaireItem?.getExtensionString(MODEL8_CONFIDENCE_URL)
+                    val m82Pred = questionnaireItem?.getExtensionString(MODEL82_PREDICTION_URL)
+                    val m82Conf = questionnaireItem?.getExtensionString(MODEL82_CONFIDENCE_URL)
+                    setAnswerFromAI(result, confidence, m6Pred, m6Conf, m8Pred, m8Conf, m82Pred, m82Conf)
+                } catch (exc: Exception) {
                     Timber.e("Failed to load photo preview: ${exc.message}")
                 }
-
-
-
-                //Suspicious/NonSuspicious
-//                //Confidence percentage
-//                val confidence = questionnaireItem?.getExtensionString(CONFIDENCE_PERCENTAGE_URL)
-//                // Individual model results
-//                val m6Pred = questionnaireItem?.getExtensionString(MODEL6_PREDICTION_URL)
-//                val m6Conf = questionnaireItem?.getExtensionString(MODEL6_CONFIDENCE_URL)
-//                val m8Pred = questionnaireItem?.getExtensionString(MODEL8_PREDICTION_URL)
-//                val m8Conf = questionnaireItem?.getExtensionString(MODEL8_CONFIDENCE_URL)
-//                val m82Pred = questionnaireItem?.getExtensionString(MODEL82_PREDICTION_URL)
-//                val m82Conf = questionnaireItem?.getExtensionString(MODEL82_CONFIDENCE_URL)
-//                setAnswerFromAI(
-//                    result, confidence,
-//                    m6Pred, m6Conf,
-//                    m8Pred, m8Conf,
-//                    m82Pred, m82Conf
-//                )
             }
 
             private fun setAnswerFromAI(
@@ -792,22 +772,22 @@ internal object CustomAttachmentViewHolderFactory :
                     stringBuilder.append("\n")
                 }
 
-//                if (!m6Pred.isNullOrEmpty()) {
-//                    stringBuilder.append("M6: $m6Pred")
-//                    if (!m6Conf.isNullOrEmpty()) stringBuilder.append(" ($m6Conf%)")
-//                    stringBuilder.append("\n")
-//                }
-//
-//                if (!m8Pred.isNullOrEmpty()) {
-//                    stringBuilder.append("M8: $m8Pred")
-//                    if (!m8Conf.isNullOrEmpty()) stringBuilder.append(" ($m8Conf%)")
-//                    stringBuilder.append("\n")
-//                }
-//
-//                if (!m82Pred.isNullOrEmpty()) {
-//                    stringBuilder.append("M82: $m82Pred")
-//                    if (!m82Conf.isNullOrEmpty()) stringBuilder.append(" ($m82Conf%)")
-//                }
+                if (!m6Pred.isNullOrEmpty()) {
+                    stringBuilder.append("M6: $m6Pred")
+                    if (!m6Conf.isNullOrEmpty()) stringBuilder.append(" ($m6Conf%)")
+                    stringBuilder.append("\n")
+                }
+
+                if (!m8Pred.isNullOrEmpty()) {
+                    stringBuilder.append("M8: $m8Pred")
+                    if (!m8Conf.isNullOrEmpty()) stringBuilder.append(" ($m8Conf%)")
+                    stringBuilder.append("\n")
+                }
+
+                if (!m82Pred.isNullOrEmpty()) {
+                    stringBuilder.append("M82: $m82Pred")
+                    if (!m82Conf.isNullOrEmpty()) stringBuilder.append(" ($m82Conf%)")
+                }
                 val finalString = stringBuilder.toString().trim()
                 if (finalString.isNotEmpty()) {
                     photoResult.text = finalString

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/register/tasks/TasksScreen.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/register/tasks/TasksScreen.kt
@@ -91,6 +91,7 @@ import com.google.android.fhir.datacapture.extensions.asStringValue
 import kotlinx.coroutines.launch
 import org.hl7.fhir.r4.model.CodeableConcept
 import org.hl7.fhir.r4.model.Coding
+import org.hl7.fhir.r4.model.Reference
 import org.hl7.fhir.r4.model.Task
 import org.hl7.fhir.r4.model.Task.TaskOutputComponent
 import org.hl7.fhir.r4.model.Task.TaskStatus
@@ -293,6 +294,8 @@ fun PendingTasksScreen(
                             mapOf(
                                 PostHogAnalytics.Props.TASK_ID to task.task.id,
                                 PostHogAnalytics.Props.TASK_STATUS to status.display,
+                                PostHogAnalytics.Props.TASK_CODE to task.task.analyticsTaskCode(),
+                                PostHogAnalytics.Props.LINKED_QUESTIONNAIRE_ID to task.task.linkedQuestionnaireId(),
                             )
                         )
 
@@ -1357,6 +1360,33 @@ fun CardItemView(
     RecommendationItem(name, phone, reason, task.task.status, taskStatusList) {
         onSelectTask(task)
     }
+}
+
+private fun Task.analyticsTaskCode(): String? =
+    if (hasCode()) {
+        code.coding
+            .mapNotNull { coding ->
+                listOfNotNull(coding.system, coding.code, coding.display)
+                    .takeIf { it.isNotEmpty() }
+                    ?.joinToString("|")
+            }
+            .takeIf { it.isNotEmpty() }
+            ?.joinToString(",")
+    } else {
+        null
+    }
+
+private fun Task.linkedQuestionnaireId(): String? {
+    val references =
+        buildList {
+            focus?.reference?.let(::add)
+            basedOn.mapNotNullTo(this) { it.reference }
+            input.mapNotNullTo(this) { (it.value as? Reference)?.reference }
+            output.mapNotNullTo(this) { (it.value as? Reference)?.reference }
+        }
+    return references
+        .firstOrNull { it.contains("Questionnaire", ignoreCase = true) }
+        ?.substringAfterLast("/")
 }
 
 @PreviewWithBackgroundExcludeGenerated

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/util/DeviceMetrics.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/util/DeviceMetrics.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021-2024 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartregister.fhircore.quest.util
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.BatteryManager
+import android.os.Build
+
+object DeviceMetrics {
+  fun snapshot(context: Context): Map<String, Any> {
+    val runtime = Runtime.getRuntime()
+    val usedMemoryMb = (runtime.totalMemory() - runtime.freeMemory()).bytesToMib()
+    val memoryInfo = ActivityManager.MemoryInfo()
+    (context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager)
+      ?.getMemoryInfo(memoryInfo)
+
+    return mapOf(
+      PostHogAnalytics.Props.BATTERY_PCT to (batteryPct(context) ?: -1),
+      PostHogAnalytics.Props.BATTERY_CHARGING to batteryCharging(context),
+      PostHogAnalytics.Props.MEMORY_USED_MB to usedMemoryMb,
+      PostHogAnalytics.Props.MEMORY_AVAILABLE_MB to memoryInfo.availMem.bytesToMib(),
+    )
+  }
+
+  fun batteryPct(context: Context): Int? =
+    (context.getSystemService(Context.BATTERY_SERVICE) as? BatteryManager)
+      ?.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+      ?.takeIf { it >= 0 }
+
+  private fun batteryCharging(context: Context): Boolean =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      (context.getSystemService(Context.BATTERY_SERVICE) as? BatteryManager)?.isCharging == true
+    } else {
+      false
+    }
+
+  private fun Long.bytesToMib(): Long = this / (1024L * 1024L)
+}

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/util/HttpConstant.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/util/HttpConstant.kt
@@ -8,3 +8,6 @@ const val SUSPICIOUS_NON_SUSPICIOUS_URL="https://midas.iisc.ac.in/CodeSystem/ai-
 const val CONFIDENCE_PERCENTAGE_URL="https://midas.iisc.ac.in/CodeSystem/ai-result-confidence"
 const val CASE_LEVEL_AI_RESULT_URL="https://midas.iisc.ac.in/CodeSystem/case-level-ai-result"
 const val REFER_CASE_URL="https://midas.iisc.ac.in/CodeSystem/refer-case"
+
+const val AI_RESULT_SUFFIX = "-ai-result"
+const val CASE_LEVEL_AI_RESULT_LINK_ID = "case-level-ai-result"

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/util/ImageQualityAnalyzer.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/util/ImageQualityAnalyzer.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021-2024 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartregister.fhircore.quest.util
+
+import android.os.Build
+import kotlin.math.pow
+import org.opencv.core.Core
+import org.opencv.core.CvType
+import org.opencv.core.Mat
+import org.opencv.core.MatOfDouble
+import org.opencv.core.Size
+import org.opencv.imgproc.Imgproc
+
+object ImageQualityAnalyzer {
+  private const val MIN_BLUR_VARIANCE = 100.0
+  private const val MIN_BRIGHTNESS = 40.0
+  private const val MAX_BRIGHTNESS = 220.0
+
+  fun analyze(mat: Mat): Map<String, Any> {
+    val gray = Mat()
+    val laplacian = Mat()
+    val blurred = Mat()
+    val residual = Mat()
+    val mean = MatOfDouble()
+    val stdDev = MatOfDouble()
+    val laplacianMean = MatOfDouble()
+    val laplacianStdDev = MatOfDouble()
+    val residualMean = MatOfDouble()
+    val residualStdDev = MatOfDouble()
+
+    try {
+      if (mat.channels() > 1) {
+        Imgproc.cvtColor(mat, gray, Imgproc.COLOR_BGR2GRAY)
+      } else {
+        mat.copyTo(gray)
+      }
+
+      Core.meanStdDev(gray, mean, stdDev)
+      Imgproc.Laplacian(gray, laplacian, CvType.CV_64F)
+      Core.meanStdDev(laplacian, laplacianMean, laplacianStdDev)
+
+      Imgproc.GaussianBlur(gray, blurred, Size(3.0, 3.0), 0.0)
+      Core.absdiff(gray, blurred, residual)
+      Core.meanStdDev(residual, residualMean, residualStdDev)
+
+      val brightness = mean.first()
+      val blurVariance = laplacianStdDev.first().pow(2.0)
+      // First-cut thresholds for launch telemetry; tune from field distributions in PostHog.
+      val isUnusable =
+        blurVariance < MIN_BLUR_VARIANCE ||
+          brightness < MIN_BRIGHTNESS ||
+          brightness > MAX_BRIGHTNESS
+
+      return mapOf(
+        PostHogAnalytics.Props.BLUR_LAPLACIAN_VARIANCE to blurVariance,
+        PostHogAnalytics.Props.BRIGHTNESS_MEAN to brightness,
+        PostHogAnalytics.Props.CONTRAST_STDDEV to stdDev.first(),
+        PostHogAnalytics.Props.NOISE_ESTIMATE to residualStdDev.first(),
+        PostHogAnalytics.Props.IS_UNUSABLE to isUnusable,
+        PostHogAnalytics.Props.DEVICE_MODEL to Build.MODEL.orEmpty(),
+        PostHogAnalytics.Props.DEVICE_MANUFACTURER to Build.MANUFACTURER.orEmpty(),
+        PostHogAnalytics.Props.OS_VERSION to Build.VERSION.SDK_INT,
+        PostHogAnalytics.Props.IMAGE_WIDTH to mat.width(),
+        PostHogAnalytics.Props.IMAGE_HEIGHT to mat.height(),
+      )
+    } finally {
+      gray.release()
+      laplacian.release()
+      blurred.release()
+      residual.release()
+      mean.release()
+      stdDev.release()
+      laplacianMean.release()
+      laplacianStdDev.release()
+      residualMean.release()
+      residualStdDev.release()
+    }
+  }
+
+  private fun MatOfDouble.first(): Double = toArray().firstOrNull() ?: 0.0
+}

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/util/PostHogAnalytics.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/util/PostHogAnalytics.kt
@@ -32,6 +32,12 @@ object PostHogAnalytics {
         const val AI_REFER_CASE = "ai_refer_case"
         const val PHOTO_CAPTURED = "photo_captured"
         const val TASK_STATUS_UPDATED = "task_status_updated"
+        const val SCREENING_STEP_COMPLETED = "screening_step_completed"
+        const val SCREENING_COMPLETED = "screening_completed"
+        const val SCREENING_ABANDONED = "screening_abandoned"
+        const val MODEL_INFERENCE_COMPLETED = "model_inference_completed"
+        const val PHOTO_RETAKEN = "photo_retaken"
+        const val IMAGE_UPLOAD_COMPLETED = "image_upload_completed"
         const val ERROR = "error"
     }
 
@@ -43,8 +49,61 @@ object PostHogAnalytics {
         const val REFER_CASE = "refer_case"
         const val AI_PREDICTION = "ai_prediction"
         const val AI_CONFIDENCE = "ai_confidence"
+        const val AI_VERDICT = "ai_verdict"
+        const val AI_OVERRIDDEN = "ai_overridden"
         const val TASK_ID = "task_id"
         const val TASK_STATUS = "task_status"
+        const val TASK_CODE = "task_code"
+        const val LINKED_QUESTIONNAIRE_ID = "linked_questionnaire_id"
+        const val QUESTIONNAIRE_KIND = "questionnaire_kind"
+        const val SCREENING_ID = "screening_id"
+        const val STEP_NAME = "step_name"
+        const val STEP_DURATION_MS = "step_duration_ms"
+        const val CUMULATIVE_DURATION_MS = "cumulative_duration_ms"
+        const val TOTAL_DURATION_MS = "total_duration_ms"
+        const val OUTCOME = "outcome"
+        const val PHOTO_COUNT = "photo_count"
+        const val RETAKE_COUNT = "retake_count"
+        const val RETAKE_INDEX = "retake_index"
+        const val BATTERY_DELTA_PCT = "battery_delta_pct"
+        const val MODEL_NAME = "model_name"
+        const val MODEL_VERSION = "model_version"
+        const val MODEL_PREDICTION = "model_prediction"
+        const val MODEL_CONFIDENCE = "model_confidence"
+        const val MODEL_ENTROPY = "model_entropy"
+        const val LOW_CONFIDENCE = "low_confidence"
+        const val IMAGE_COUNT = "image_count"
+        const val SUSPICIOUS_IMAGE_COUNT = "suspicious_image_count"
+        const val NON_SUSPICIOUS_IMAGE_COUNT = "non_suspicious_image_count"
+        const val LOW_CONFIDENCE_IMAGE_COUNT = "low_confidence_image_count"
+        const val MEAN_CONFIDENCE = "mean_confidence"
+        const val INFERENCE_TIME_MS = "inference_time_ms"
+        const val COMBINED_INFERENCE_TIME_MS = "combined_inference_time_ms"
+        const val CAPTURE_TO_RESULT_MS = "capture_to_result_ms"
+        const val BATTERY_PCT = "battery_pct"
+        const val BATTERY_CHARGING = "battery_charging"
+        const val MEMORY_USED_MB = "memory_used_mb"
+        const val MEMORY_AVAILABLE_MB = "memory_available_mb"
+        const val BLUR_LAPLACIAN_VARIANCE = "blur_laplacian_variance"
+        const val BRIGHTNESS_MEAN = "brightness_mean"
+        const val CONTRAST_STDDEV = "contrast_stddev"
+        const val NOISE_ESTIMATE = "noise_estimate"
+        const val IS_UNUSABLE = "is_unusable"
+        const val DEVICE_MODEL = "device_model"
+        const val DEVICE_MANUFACTURER = "device_manufacturer"
+        const val OS_VERSION = "os_version"
+        const val IMAGE_WIDTH = "image_width"
+        const val IMAGE_HEIGHT = "image_height"
+        const val TIME_TO_CAPTURE_MS = "time_to_capture_ms"
+        const val SYNC_STATUS = "sync_status"
+        const val SYNC_DURATION_MS = "sync_duration_ms"
+        const val PENDING_IMAGES_AFTER = "pending_images_after"
+        const val PENDING_CASES_AFTER = "pending_cases_after"
+        const val DOCUMENT_ID = "document_id"
+        const val UPLOAD_DURATION_MS = "upload_duration_ms"
+        const val RESPONSE_CODE = "response_code"
+        const val PENDING_DOCUMENTS = "pending_documents"
+        const val BYTES_UPLOADED = "bytes_uploaded"
         const val ERROR_MESSAGE = "error_message"
         const val ERROR_SOURCE = "error_source"
     }
@@ -92,9 +151,21 @@ object PostHogAnalytics {
      * Capture a generic event with optional properties.
      * Site and flwid are automatically associated via identify().
      */
-    fun capture(event: String, properties: Map<String, Any>? = null) {
+    fun capture(event: String, properties: Map<String, Any?>? = null) {
         try {
-            PostHog.capture(event, properties = properties)
+            val cleanProperties =
+                properties
+                    ?.filterValues { value ->
+                        when (value) {
+                            null -> false
+                            is String -> value.isNotBlank()
+                            is Collection<*> -> value.isNotEmpty()
+                            is Map<*, *> -> value.isNotEmpty()
+                            else -> true
+                        }
+                    }
+                    ?.mapValues { it.value as Any }
+            PostHog.capture(event, properties = cleanProperties)
         } catch (e: Exception) {
             Timber.e(e, "PostHog capture failed for event: $event")
         }
@@ -114,12 +185,12 @@ object PostHogAnalytics {
     /**
      * Capture an error event for logging in PostHog.
      */
-    fun captureError(source: String, message: String, extra: Map<String, Any>? = null) {
+    fun captureError(source: String, message: String, extra: Map<String, Any?>? = null) {
         val props = mutableMapOf<String, Any>(
             Props.ERROR_SOURCE to source,
             Props.ERROR_MESSAGE to message,
         )
-        extra?.let { props.putAll(it) }
+        extra?.forEach { (key, value) -> value?.let { props[key] = it } }
         capture(Events.ERROR, props)
     }
 
@@ -129,9 +200,21 @@ object PostHogAnalytics {
      * (e.g., sync failures, API errors). Uncaught crashes are
      * auto-captured via errorTrackingConfig.autoCapture = true.
      */
-    fun captureException(throwable: Throwable, extra: Map<String, Any>? = null) {
+    fun captureException(throwable: Throwable, extra: Map<String, Any?>? = null) {
         try {
-            PostHog.captureException(throwable, properties = extra)
+            val cleanProperties =
+                extra
+                    ?.filterValues { value ->
+                        when (value) {
+                            null -> false
+                            is String -> value.isNotBlank()
+                            is Collection<*> -> value.isNotEmpty()
+                            is Map<*, *> -> value.isNotEmpty()
+                            else -> true
+                        }
+                    }
+                    ?.mapValues { it.value as Any }
+            PostHog.captureException(throwable, properties = cleanProperties)
         } catch (e: Exception) {
             Timber.e(e, "PostHog captureException failed")
         }

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/util/PostHogAnalyticsLogger.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/util/PostHogAnalyticsLogger.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021-2024 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartregister.fhircore.quest.util
+
+import javax.inject.Inject
+import org.smartregister.fhircore.engine.util.analytics.AnalyticsLogger
+
+class PostHogAnalyticsLogger @Inject constructor() : AnalyticsLogger {
+  override fun capture(event: String, properties: Map<String, Any?>?) {
+    PostHogAnalytics.capture(event, properties)
+  }
+}

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/util/ScreeningTimer.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/util/ScreeningTimer.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2021-2024 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartregister.fhircore.quest.util
+
+import android.os.SystemClock
+import java.util.UUID
+
+object ScreeningTimer {
+  private const val MAX_ACTIVE_SCREENINGS = 16
+
+  private data class State(
+    val startMs: Long,
+    var lastStepMs: Long,
+    var retakeCount: Int = 0,
+    var photoCount: Int = 0,
+    val batteryStartPct: Int? = null,
+  )
+
+  interface Clock {
+    fun nowMs(): Long
+  }
+
+  private val activeScreenings =
+    object : LinkedHashMap<String, State>(MAX_ACTIVE_SCREENINGS, 0.75f, true) {
+      override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, State>?): Boolean =
+        size > MAX_ACTIVE_SCREENINGS
+    }
+
+  private var clock: Clock =
+    object : Clock {
+      override fun nowMs(): Long = SystemClock.elapsedRealtime()
+    }
+
+  private var eventSink: (String, Map<String, Any?>) -> Unit = { event, props ->
+    PostHogAnalytics.capture(event, props)
+  }
+
+  @Synchronized
+  fun start(batteryStartPct: Int? = null): String {
+    val now = clock.nowMs()
+    val screeningId = UUID.randomUUID().toString()
+    activeScreenings[screeningId] = State(now, now, batteryStartPct = batteryStartPct)
+    return screeningId
+  }
+
+  @Synchronized
+  fun markStep(screeningId: String?, name: String) {
+    if (screeningId.isNullOrBlank()) return
+    val state = activeScreenings[screeningId] ?: return
+    val now = clock.nowMs()
+    val stepDuration = now - state.lastStepMs
+    val cumulativeDuration = now - state.startMs
+    state.lastStepMs = now
+
+    capture(
+      PostHogAnalytics.Events.SCREENING_STEP_COMPLETED,
+      mapOf(
+        PostHogAnalytics.Props.SCREENING_ID to screeningId,
+        PostHogAnalytics.Props.STEP_NAME to name,
+        PostHogAnalytics.Props.STEP_DURATION_MS to stepDuration,
+        PostHogAnalytics.Props.CUMULATIVE_DURATION_MS to cumulativeDuration,
+      ),
+    )
+  }
+
+  @Synchronized
+  fun incrementRetake(screeningId: String?): Int {
+    if (screeningId.isNullOrBlank()) return 0
+    val state = activeScreenings[screeningId] ?: return 0
+    state.retakeCount += 1
+    capture(
+      PostHogAnalytics.Events.PHOTO_RETAKEN,
+      mapOf(
+        PostHogAnalytics.Props.SCREENING_ID to screeningId,
+        PostHogAnalytics.Props.RETAKE_INDEX to state.retakeCount,
+      ),
+    )
+    return state.retakeCount
+  }
+
+  @Synchronized
+  fun incrementPhoto(screeningId: String?): Int {
+    if (screeningId.isNullOrBlank()) return 0
+    val state = activeScreenings[screeningId] ?: return 0
+    state.photoCount += 1
+    return state.photoCount
+  }
+
+  @Synchronized
+  fun end(screeningId: String?, outcome: String, extraProps: Map<String, Any?>? = null) {
+    if (screeningId.isNullOrBlank()) return
+    val state = activeScreenings.remove(screeningId) ?: return
+    val now = clock.nowMs()
+    val props =
+      mutableMapOf<String, Any?>(
+        PostHogAnalytics.Props.SCREENING_ID to screeningId,
+        PostHogAnalytics.Props.TOTAL_DURATION_MS to now - state.startMs,
+        PostHogAnalytics.Props.OUTCOME to outcome,
+        PostHogAnalytics.Props.PHOTO_COUNT to state.photoCount,
+        PostHogAnalytics.Props.RETAKE_COUNT to state.retakeCount,
+      )
+    extraProps?.let(props::putAll)
+    state.batteryStartPct?.let { startPct ->
+      (props[PostHogAnalytics.Props.BATTERY_PCT] as? Int)?.let { endPct ->
+        props[PostHogAnalytics.Props.BATTERY_DELTA_PCT] = endPct - startPct
+      }
+    }
+
+    capture(PostHogAnalytics.Events.SCREENING_COMPLETED, props)
+    if (outcome == "abandoned") {
+      capture(PostHogAnalytics.Events.SCREENING_ABANDONED, props)
+    }
+  }
+
+  private fun capture(event: String, props: Map<String, Any?>) {
+    eventSink(event, props)
+  }
+
+  @Synchronized
+  fun resetForTesting(
+    testClock: Clock,
+    testEventSink: (String, Map<String, Any?>) -> Unit = { event, props ->
+      PostHogAnalytics.capture(event, props)
+    },
+  ) {
+    activeScreenings.clear()
+    clock = testClock
+    eventSink = testEventSink
+  }
+
+  @Synchronized
+  fun clearForTesting() {
+    activeScreenings.clear()
+    clock =
+      object : Clock {
+        override fun nowMs(): Long = SystemClock.elapsedRealtime()
+      }
+    eventSink = { event, props -> PostHogAnalytics.capture(event, props) }
+  }
+}

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/util/dailog/ForegroundSyncDialog.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/util/dailog/ForegroundSyncDialog.kt
@@ -1,14 +1,17 @@
 package org.smartregister.fhircore.quest.util.dailog
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.sp
+import org.smartregister.fhircore.quest.theme.Theme
 import org.smartregister.fhircore.quest.theme.body18Medium
 import org.smartregister.fhircore.quest.theme.bodyMedium
 import org.smartregister.fhircore.quest.theme.bodyNormal
+import org.smartregister.fhircore.quest.theme.getTextColor
 
 /**
  * Created by Jeetesh Surana.
@@ -27,20 +30,28 @@ fun ForegroundSyncDialog(
     onConfirm: () -> Unit
 ) {
     if (showDialog) {
+        // Resolve dark-theme state once in the caller's composition and reuse
+        // it for both the dialog surface and every Text inside its lambdas.
+        // The AlertDialog content runs in its own subcomposition (separate
+        // Window), and on this screen it can disagree with the outer tree
+        // after navigation — which produced a white-on-white (blank) dialog.
+        val darkTheme = isSystemInDarkTheme()
         AlertDialog(
             shape = RectangleShape,
+            backgroundColor = Theme.getWhiteBackground(darkTheme),
+            contentColor = getTextColor(darkTheme),
             onDismissRequest = onDismiss,
-            title = { Text(title, style = body18Medium()) },
-            text = { Text(content, style = bodyNormal(14.sp)) },
+            title = { Text(title, style = body18Medium(darkTheme)) },
+            text = { Text(content, style = bodyNormal(14.sp, darkTheme)) },
             confirmButton = { // Okay button
                 TextButton(onClick = onDismiss) {
-                    Text(dismissButtonText, style = bodyMedium(16.sp))
+                    Text(dismissButtonText, style = bodyMedium(16.sp, darkTheme))
                 }
             },
             dismissButton = { // sync button
                 //Allowing users always have an option to trigger sync manually
                 TextButton(onClick = onConfirm) {
-                    Text(confirmButtonText, style = bodyMedium(16.sp))
+                    Text(confirmButtonText, style = bodyMedium(16.sp, darkTheme))
                 }
             }
         )

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/RegisterContentTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/RegisterContentTest.kt
@@ -55,7 +55,6 @@ class RegisterContentTest : RobolectricTest() {
     sourceGroup: String,
   ): StructureMapExtractionContext {
     return StructureMapExtractionContext(
-      context = context,
       transformSupportServices = transformSupportServices,
       structureMapProvider = { _: String, _: IWorkerContext ->
         StructureMapUtilities(worker, transformSupportServices)

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/app/AppConfigService.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/app/AppConfigService.kt
@@ -21,13 +21,14 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import org.hl7.fhir.r4.model.Coding
 import org.hl7.fhir.r4.model.ResourceType
+import org.smartregister.fhircore.engine.di.BaseUrlsHolder
 import org.smartregister.fhircore.engine.configuration.app.AuthConfiguration
 import org.smartregister.fhircore.engine.configuration.app.ConfigService
 import org.smartregister.fhircore.engine.sync.ResourceTag
 
 class AppConfigService @Inject constructor(@ApplicationContext val context: Context) :
   ConfigService {
-  override fun provideAuthConfiguration() =
+  override fun provideAuthConfiguration(baseUrlsHolder: BaseUrlsHolder) =
     AuthConfiguration(
       fhirServerBaseUrl = "http://fake.base.url.com",
       oauthServerBaseUrl = "http://fake.keycloak.url.com",

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/app/fakes/Faker.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/app/fakes/Faker.kt
@@ -21,6 +21,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.gson.Gson
 import dagger.hilt.android.testing.HiltTestApplication
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
@@ -61,14 +62,16 @@ object Faker {
   fun buildTestConfigurationRegistry(): ConfigurationRegistry {
     val fhirResourceService = mockk<FhirResourceService>()
     val fhirResourceDataSource = spyk(FhirResourceDataSource(fhirResourceService))
+    val sharedPreferencesHelper = mockk<SharedPreferencesHelper>(relaxed = true)
     coEvery { fhirResourceService.getResource(any()) } returns Bundle()
+    every { sharedPreferencesHelper.read(any(), any<String>()) } answers { secondArg() }
 
     val configurationRegistry =
       spyk(
         ConfigurationRegistry(
           fhirEngine = mockk(),
           fhirResourceDataSource = fhirResourceDataSource,
-          sharedPreferencesHelper = mockk(),
+          sharedPreferencesHelper = sharedPreferencesHelper,
           dispatcherProvider = mockk(),
           configService = mockk(),
           json = json,

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/robolectric/RobolectricTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/robolectric/RobolectricTest.kt
@@ -58,7 +58,7 @@ import org.smartregister.fhircore.quest.app.fakes.FakeKeyStore
 import org.smartregister.fhircore.quest.coroutine.CoroutineTestRule
 
 @RunWith(FhircoreTestRunner::class)
-@Config(sdk = [Build.VERSION_CODES.O_MR1], application = HiltTestApplication::class)
+@Config(sdk = [Build.VERSION_CODES.Q], application = HiltTestApplication::class)
 abstract class RobolectricTest {
 
   @get:Rule(order = 11) val workManagerRule = WorkManagerRule()

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/main/AppMainActivityTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/main/AppMainActivityTest.kt
@@ -92,14 +92,14 @@ class AppMainActivityTest : ActivityRobolectricTest() {
   @Test
   fun testOnSyncWithSyncStateInProgress() {
     val viewModel = appMainActivity.appMainViewModel
-    val initialSyncTime = viewModel.appMainUiState.value.lastSyncTime
+    val initialSyncTime = viewModel.retrieveLastSyncTimestamp()
 
     appMainActivity.onSync(
       CurrentSyncJobStatus.Running(SyncJobStatus.InProgress(SyncOperation.DOWNLOAD)),
     )
 
     // Timestamp will only updated for Finished.
-    Assert.assertEquals(initialSyncTime, viewModel.appMainUiState.value.lastSyncTime)
+    Assert.assertEquals(initialSyncTime, viewModel.retrieveLastSyncTimestamp())
   }
 
   @Test
@@ -109,19 +109,19 @@ class AppMainActivityTest : ActivityRobolectricTest() {
       SharedPreferenceKey.LAST_SYNC_TIMESTAMP.name,
       "2022-05-19",
     )
-    val initialTimestamp = viewModel.appMainUiState.value.lastSyncTime
+    val initialTimestamp = viewModel.retrieveLastSyncTimestamp()
     val syncJobStatus = CurrentSyncJobStatus.Failed(OffsetDateTime.now())
     appMainActivity.onSync(syncJobStatus)
 
     // Timestamp not update if status is Failed. Initial timestamp remains the same
-    Assert.assertEquals(initialTimestamp, viewModel.appMainUiState.value.lastSyncTime)
+    Assert.assertEquals(initialTimestamp, viewModel.retrieveLastSyncTimestamp())
   }
 
   @Test
   fun testOnSyncWithSyncStateFailedWhenTimestampIsNotNull() {
     val viewModel = appMainActivity.appMainViewModel
     appMainActivity.onSync(CurrentSyncJobStatus.Failed(OffsetDateTime.now()))
-    Assert.assertNotNull(viewModel.appMainUiState.value.lastSyncTime)
+    Assert.assertNull(viewModel.retrieveLastSyncTimestamp())
   }
 
   @Test

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/main/AppMainViewModelTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/main/AppMainViewModelTest.kt
@@ -23,6 +23,7 @@ import android.widget.Toast
 import androidx.navigation.NavController
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.WorkManager
+import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.sync.CurrentSyncJobStatus
 import com.google.gson.Gson
 import dagger.hilt.android.testing.BindValue
@@ -100,6 +101,7 @@ class AppMainViewModelTest : RobolectricTest() {
   private val registerRepository: RegisterRepository = mockk()
   private val application: Context = ApplicationProvider.getApplicationContext()
   private val syncBroadcaster: SyncBroadcaster = mockk(relaxed = true)
+  private val fhirEngine: FhirEngine = mockk(relaxed = true)
   private lateinit var sharedPreferencesHelper: SharedPreferencesHelper
   private lateinit var appMainViewModel: AppMainViewModel
 
@@ -123,6 +125,7 @@ class AppMainViewModelTest : RobolectricTest() {
           dispatcherProvider = dispatcherProvider,
           workManager = workManager,
           fhirCarePlanGenerator = fhirCarePlanGenerator,
+          fhirEngine = fhirEngine,
         ),
       )
     runBlocking { configurationRegistry.loadConfigurations("app/debug", application) }

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/pin/PinViewModelTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/pin/PinViewModelTest.kt
@@ -18,6 +18,7 @@ package org.smartregister.fhircore.quest.ui.pin
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.fhir.FhirEngine
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import io.mockk.coEvery
@@ -54,6 +55,7 @@ class PinViewModelTest : RobolectricTest() {
 
   private val sharedPreferenceHelper: SharedPreferencesHelper = mockk(relaxUnitFun = true)
   private var secureSharedPreference: SecureSharedPreference = mockk(relaxUnitFun = true)
+  private val openSrpFhirEngine: FhirEngine = mockk(relaxed = true)
   private val configurationRegistry = Faker.buildTestConfigurationRegistry()
   private lateinit var pinViewModel: PinViewModel
 
@@ -66,6 +68,7 @@ class PinViewModelTest : RobolectricTest() {
         sharedPreferences = sharedPreferenceHelper,
         configurationRegistry = configurationRegistry,
         dispatcherProvider = dispatcherProvider,
+        openSrpFhirEngine = openSrpFhirEngine,
       )
   }
 

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModelAiSummaryTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModelAiSummaryTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021-2024 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartregister.fhircore.quest.ui.questionnaire
+
+import com.google.android.fhir.FhirEngine
+import com.google.android.fhir.workflow.FhirOperator
+import io.mockk.mockk
+import org.hl7.fhir.r4.model.Attachment
+import org.hl7.fhir.r4.model.Questionnaire
+import org.hl7.fhir.r4.model.QuestionnaireResponse
+import org.hl7.fhir.r4.model.StringType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.smartregister.fhircore.engine.configuration.ConfigurationRegistry
+import org.smartregister.fhircore.engine.data.local.DefaultRepository
+import org.smartregister.fhircore.engine.rulesengine.ResourceDataRulesExecutor
+import org.smartregister.fhircore.engine.sync.SyncBroadcaster
+import org.smartregister.fhircore.engine.task.FhirCarePlanGenerator
+import org.smartregister.fhircore.engine.util.DispatcherProvider
+import org.smartregister.fhircore.engine.util.SecureSharedPreference
+import org.smartregister.fhircore.engine.util.SharedPreferencesHelper
+import org.smartregister.fhircore.engine.util.fhirpath.FhirPathDataExtractor
+import org.smartregister.fhircore.engine.util.helper.TransformSupportServices
+import org.smartregister.fhircore.quest.util.CONFIDENCE_PERCENTAGE_URL
+import org.smartregister.fhircore.quest.util.SUSPICIOUS_NON_SUSPICIOUS_URL
+
+class QuestionnaireViewModelAiSummaryTest {
+
+  @Test
+  fun `summarizeAiInference returns case-level image aggregates`() {
+    val viewModel = questionnaireViewModel()
+    val questionnaire =
+      Questionnaire().apply {
+        addItem(aiQuestionnaireItem("image-1", "Suspicious", "70"))
+        addItem(aiQuestionnaireItem("image-2", "Non-Suspicious", "55"))
+      }
+    val questionnaireResponse =
+      QuestionnaireResponse().apply {
+        addItem(attachmentResponseItem("image-1", "first.jpg"))
+        addItem(attachmentResponseItem("image-2", "second.jpg"))
+      }
+
+    val summary = viewModel.summarizeAiInference(questionnaireResponse, questionnaire)
+
+    assertTrue(summary.isSuspicious)
+    assertEquals(listOf("first.jpg"), summary.suspiciousImages)
+    assertEquals(2, summary.imageCount)
+    assertEquals(1, summary.suspiciousImageCount)
+    assertEquals(1, summary.nonSuspiciousImageCount)
+    assertEquals(1, summary.lowConfidenceImageCount)
+    assertEquals(62.5f, summary.meanConfidence)
+  }
+
+  private fun aiQuestionnaireItem(
+    linkId: String,
+    prediction: String,
+    confidence: String,
+  ): Questionnaire.QuestionnaireItemComponent =
+    Questionnaire.QuestionnaireItemComponent().apply {
+      this.linkId = linkId
+      addExtension(SUSPICIOUS_NON_SUSPICIOUS_URL, StringType(prediction))
+      addExtension(CONFIDENCE_PERCENTAGE_URL, StringType(confidence))
+    }
+
+  private fun attachmentResponseItem(
+    linkId: String,
+    title: String,
+  ): QuestionnaireResponse.QuestionnaireResponseItemComponent =
+    QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+      this.linkId = linkId
+      addAnswer(
+        QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+          value = Attachment().apply { this.title = title }
+        },
+      )
+    }
+
+  private fun questionnaireViewModel(): QuestionnaireViewModel =
+    QuestionnaireViewModel(
+      defaultRepository = mockk<DefaultRepository>(relaxed = true),
+      dispatcherProvider = mockk<DispatcherProvider>(relaxed = true),
+      fhirCarePlanGenerator = mockk<FhirCarePlanGenerator>(relaxed = true),
+      resourceDataRulesExecutor = mockk<ResourceDataRulesExecutor>(relaxed = true),
+      transformSupportServices = mockk<TransformSupportServices>(relaxed = true),
+      sharedPreferencesHelper = mockk<SharedPreferencesHelper>(relaxed = true),
+      secureSharedPreference = mockk<SecureSharedPreference>(relaxed = true),
+      fhirOperator = mockk<FhirOperator>(relaxed = true),
+      fhirPathDataExtractor = mockk<FhirPathDataExtractor>(relaxed = true),
+      configurationRegistry = mockk<ConfigurationRegistry>(relaxed = true),
+      syncBroadcaster = mockk<SyncBroadcaster>(relaxed = true),
+      fhirEngine = mockk<FhirEngine>(relaxed = true),
+    )
+}

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModelTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModelTest.kt
@@ -510,7 +510,7 @@ class QuestionnaireViewModelTest : RobolectricTest() {
     }
 
   @Test
-  fun testCheckIfSuspiciousReturnsTrueFromAnswerExtensionWithoutHiddenItem() {
+  fun testSummarizeAiInferenceFlagsSuspiciousFromAnswerExtensionWithoutHiddenItem() {
     val questionnaireResponse =
       screeningQuestionnaireResponse(
         aiResult = "Suspicious",
@@ -518,11 +518,11 @@ class QuestionnaireViewModelTest : RobolectricTest() {
         includeHiddenItem = false,
       )
 
-    Assert.assertTrue(questionnaireViewModel.checkIfSuspicious(questionnaireResponse))
+    Assert.assertTrue(questionnaireViewModel.summarizeAiInference(questionnaireResponse).isSuspicious)
   }
 
   @Test
-  fun testCheckIfSuspiciousReturnsTrueFromExistingHiddenResult() {
+  fun testSummarizeAiInferenceFlagsSuspiciousFromExistingHiddenResult() {
     val questionnaireResponse =
       screeningQuestionnaireResponse(
         aiResult = null,
@@ -531,11 +531,11 @@ class QuestionnaireViewModelTest : RobolectricTest() {
         hiddenAiResult = "Suspicious|94.2",
       )
 
-    Assert.assertTrue(questionnaireViewModel.checkIfSuspicious(questionnaireResponse))
+    Assert.assertTrue(questionnaireViewModel.summarizeAiInference(questionnaireResponse).isSuspicious)
   }
 
   @Test
-  fun testCheckIfSuspiciousUpdatesHiddenResultAndSuspiciousImagesFromAnswerExtension() {
+  fun testSummarizeAiInferenceUpdatesHiddenResultAndCollectsSuspiciousImages() {
     val questionnaireResponse =
       screeningQuestionnaireResponse(
         aiResult = "Suspicious",
@@ -543,15 +543,14 @@ class QuestionnaireViewModelTest : RobolectricTest() {
         includeHiddenItem = true,
       )
 
-    Assert.assertTrue(questionnaireViewModel.checkIfSuspicious(questionnaireResponse))
+    val summary = questionnaireViewModel.summarizeAiInference(questionnaireResponse)
+
+    Assert.assertTrue(summary.isSuspicious)
+    Assert.assertEquals(listOf("screening-image.jpg"), summary.suspiciousImages)
 
     val imageGroup = questionnaireResponse.item.first().item.first()
     val hiddenItem = imageGroup.item.first { it.linkId == "patient-screening-image-1-ai-result" }
     Assert.assertEquals("Suspicious|94.2", hiddenItem.answer.first().value.primitiveValue())
-    Assert.assertEquals(
-      listOf("screening-image.jpg"),
-      questionnaireViewModel.getSuspiciousImages(questionnaireResponse),
-    )
   }
 
   private fun screeningQuestionnaireResponse(

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModelTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/questionnaire/QuestionnaireViewModelTest.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.hl7.fhir.r4.model.Address
+import org.hl7.fhir.r4.model.Attachment
 import org.hl7.fhir.r4.model.Basic
 import org.hl7.fhir.r4.model.Bundle
 import org.hl7.fhir.r4.model.CodeableConcept
@@ -83,8 +84,10 @@ import org.smartregister.fhircore.engine.domain.model.ActionParameterType
 import org.smartregister.fhircore.engine.domain.model.RuleConfig
 import org.smartregister.fhircore.engine.rulesengine.ConfigRulesExecutor
 import org.smartregister.fhircore.engine.rulesengine.ResourceDataRulesExecutor
+import org.smartregister.fhircore.engine.sync.SyncBroadcaster
 import org.smartregister.fhircore.engine.task.FhirCarePlanGenerator
 import org.smartregister.fhircore.engine.util.DispatcherProvider
+import org.smartregister.fhircore.engine.util.SecureSharedPreference
 import org.smartregister.fhircore.engine.util.SharedPreferenceKey
 import org.smartregister.fhircore.engine.util.SharedPreferencesHelper
 import org.smartregister.fhircore.engine.util.extension.appendPractitionerInfo
@@ -99,6 +102,8 @@ import org.smartregister.fhircore.engine.util.fhirpath.FhirPathDataExtractor
 import org.smartregister.fhircore.quest.app.fakes.Faker
 import org.smartregister.fhircore.quest.robolectric.RobolectricTest
 import org.smartregister.fhircore.quest.ui.questionnaire.QuestionnaireViewModel.Companion.CONTAINED_LIST_TITLE
+import org.smartregister.fhircore.quest.util.CONFIDENCE_PERCENTAGE_URL
+import org.smartregister.fhircore.quest.util.SUSPICIOUS_NON_SUSPICIOUS_URL
 import org.smartregister.model.practitioner.FhirPractitionerDetails
 import org.smartregister.model.practitioner.PractitionerDetails
 
@@ -129,6 +134,8 @@ class QuestionnaireViewModelTest : RobolectricTest() {
   private val context: Application = ApplicationProvider.getApplicationContext()
   private val fhirOperator: FhirOperator = mockk()
   private val configRulesExecutor: ConfigRulesExecutor = mockk()
+  private val secureSharedPreference: SecureSharedPreference = mockk(relaxed = true)
+  private val syncBroadcaster: SyncBroadcaster = mockk(relaxed = true)
   private val patient =
     Faker.buildPatient().apply {
       address =
@@ -185,9 +192,12 @@ class QuestionnaireViewModelTest : RobolectricTest() {
           resourceDataRulesExecutor = resourceDataRulesExecutor,
           transformSupportServices = mockk(),
           sharedPreferencesHelper = sharedPreferencesHelper,
+          secureSharedPreference = secureSharedPreference,
           fhirOperator = fhirOperator,
           fhirPathDataExtractor = fhirPathDataExtractor,
           configurationRegistry = configurationRegistry,
+          syncBroadcaster = syncBroadcaster,
+          fhirEngine = fhirEngine,
         ),
       )
 
@@ -500,6 +510,103 @@ class QuestionnaireViewModelTest : RobolectricTest() {
     }
 
   @Test
+  fun testCheckIfSuspiciousReturnsTrueFromAnswerExtensionWithoutHiddenItem() {
+    val questionnaireResponse =
+      screeningQuestionnaireResponse(
+        aiResult = "Suspicious",
+        confidence = "94.2",
+        includeHiddenItem = false,
+      )
+
+    Assert.assertTrue(questionnaireViewModel.checkIfSuspicious(questionnaireResponse))
+  }
+
+  @Test
+  fun testCheckIfSuspiciousReturnsTrueFromExistingHiddenResult() {
+    val questionnaireResponse =
+      screeningQuestionnaireResponse(
+        aiResult = null,
+        confidence = null,
+        includeHiddenItem = true,
+        hiddenAiResult = "Suspicious|94.2",
+      )
+
+    Assert.assertTrue(questionnaireViewModel.checkIfSuspicious(questionnaireResponse))
+  }
+
+  @Test
+  fun testCheckIfSuspiciousUpdatesHiddenResultAndSuspiciousImagesFromAnswerExtension() {
+    val questionnaireResponse =
+      screeningQuestionnaireResponse(
+        aiResult = "Suspicious",
+        confidence = "94.2",
+        includeHiddenItem = true,
+      )
+
+    Assert.assertTrue(questionnaireViewModel.checkIfSuspicious(questionnaireResponse))
+
+    val imageGroup = questionnaireResponse.item.first().item.first()
+    val hiddenItem = imageGroup.item.first { it.linkId == "patient-screening-image-1-ai-result" }
+    Assert.assertEquals("Suspicious|94.2", hiddenItem.answer.first().value.primitiveValue())
+    Assert.assertEquals(
+      listOf("screening-image.jpg"),
+      questionnaireViewModel.getSuspiciousImages(questionnaireResponse),
+    )
+  }
+
+  private fun screeningQuestionnaireResponse(
+    aiResult: String?,
+    confidence: String?,
+    includeHiddenItem: Boolean,
+    hiddenAiResult: String? = null,
+  ) =
+    QuestionnaireResponse().apply {
+      addItem(
+        QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+          linkId = "screening-group"
+          addItem(
+            QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+              linkId = "patient-screening-image-group"
+              addItem(
+                QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+                  linkId = "patient-screening-image-1"
+                  addAnswer(
+                    QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                      aiResult?.let {
+                        addExtension(SUSPICIOUS_NON_SUSPICIOUS_URL, StringType(it))
+                      }
+                      confidence?.let { addExtension(CONFIDENCE_PERCENTAGE_URL, StringType(it)) }
+                      value =
+                        Attachment().apply {
+                          contentType = "image/jpeg"
+                          title = "screening-image.jpg"
+                          url = "DocumentReference/test-document/\$binary-access-read"
+                        }
+                    },
+                  )
+                },
+              )
+              if (includeHiddenItem) {
+                addItem(
+                  QuestionnaireResponse.QuestionnaireResponseItemComponent().apply {
+                    linkId = "patient-screening-image-1-ai-result"
+                    hiddenAiResult?.let {
+                      addAnswer(
+                        QuestionnaireResponse.QuestionnaireResponseItemAnswerComponent().apply {
+                          value = StringType(it)
+                        },
+                      )
+                    }
+                  },
+                )
+              }
+            },
+          )
+        },
+      )
+    }
+
+  @Test
   fun testRetrieveQuestionnaireShouldReturnValidQuestionnaire() = runTest {
     coEvery { fhirEngine.get(ResourceType.Questionnaire, questionnaireConfig.id) } returns
       samplePatientRegisterQuestionnaire
@@ -508,6 +615,7 @@ class QuestionnaireViewModelTest : RobolectricTest() {
       questionnaireViewModel.retrieveQuestionnaire(
         questionnaireConfig = questionnaireConfig,
         actionParameters = emptyList(),
+        languageCode = questionnaireViewModel.languageCode,
       )
 
     Assert.assertNotNull(questionnaire)
@@ -563,6 +671,7 @@ class QuestionnaireViewModelTest : RobolectricTest() {
       questionnaireViewModel.retrieveQuestionnaire(
         questionnaireConfig = newQuestionnaireConfig,
         actionParameters = actionParameter,
+        languageCode = questionnaireViewModel.languageCode,
       )
     Assert.assertNotNull(questionnaire)
 

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/register/RegisterFragmentTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/ui/register/RegisterFragmentTest.kt
@@ -22,6 +22,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.commitNow
 import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
+import com.google.android.fhir.FhirEngine
 import com.google.android.fhir.sync.CurrentSyncJobStatus
 import com.google.android.fhir.sync.SyncJobStatus
 import com.google.android.fhir.sync.SyncOperation
@@ -56,6 +57,7 @@ import org.smartregister.fhircore.engine.domain.model.ResourceData
 import org.smartregister.fhircore.engine.domain.model.SnackBarMessageConfig
 import org.smartregister.fhircore.engine.domain.model.ToolBarHomeNavigation
 import org.smartregister.fhircore.engine.util.DispatcherProvider
+import org.smartregister.fhircore.engine.util.SecureSharedPreference
 import org.smartregister.fhircore.quest.app.fakes.Faker
 import org.smartregister.fhircore.quest.event.EventBus
 import org.smartregister.fhircore.quest.navigation.NavigationArg
@@ -96,7 +98,9 @@ class RegisterFragmentTest : RobolectricTest() {
           configurationRegistry = configurationRegistry,
           sharedPreferencesHelper = Faker.buildSharedPreferencesHelper(),
           dispatcherProvider = dispatcherProvider,
+          secureSharedPreference = mockk<SecureSharedPreference>(relaxed = true),
           resourceDataRulesExecutor = mockk(),
+          fhirEngine = mockk<FhirEngine>(relaxed = true),
         ),
       )
     registerFragmentMock = mockk()

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/util/ImageQualityAnalyzerTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/util/ImageQualityAnalyzerTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021-2024 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartregister.fhircore.quest.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeNoException
+import org.junit.Before
+import org.junit.Test
+import org.opencv.core.CvType
+import org.opencv.core.Mat
+import org.opencv.core.Scalar
+
+class ImageQualityAnalyzerTest {
+
+  @Before
+  fun loadOpenCv() {
+    try {
+      System.loadLibrary("opencv_java4")
+    } catch (exception: UnsatisfiedLinkError) {
+      assumeNoException(exception)
+    }
+  }
+
+  @Test
+  fun `analyze returns image quality metrics for synthetic image`() {
+    val mat = Mat(32, 32, CvType.CV_8UC3, Scalar(128.0, 128.0, 128.0))
+    try {
+      val props = ImageQualityAnalyzer.analyze(mat)
+
+      assertEquals(32, props[PostHogAnalytics.Props.IMAGE_WIDTH])
+      assertEquals(32, props[PostHogAnalytics.Props.IMAGE_HEIGHT])
+      assertTrue((props[PostHogAnalytics.Props.BRIGHTNESS_MEAN] as Double) > 0.0)
+      assertTrue(props.containsKey(PostHogAnalytics.Props.BLUR_LAPLACIAN_VARIANCE))
+      assertTrue(props.containsKey(PostHogAnalytics.Props.CONTRAST_STDDEV))
+      assertTrue(props.containsKey(PostHogAnalytics.Props.NOISE_ESTIMATE))
+      assertEquals(true, props[PostHogAnalytics.Props.IS_UNUSABLE])
+    } finally {
+      mat.release()
+    }
+  }
+}

--- a/android/quest/src/test/java/org/smartregister/fhircore/quest/util/ScreeningTimerTest.kt
+++ b/android/quest/src/test/java/org/smartregister/fhircore/quest/util/ScreeningTimerTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021-2024 Ona Systems, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.smartregister.fhircore.quest.util
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScreeningTimerTest {
+
+  @After
+  fun tearDown() {
+    ScreeningTimer.clearForTesting()
+  }
+
+  @Test
+  fun `start step retake photo and end emit expected screening analytics`() {
+    val clock = FakeClock(1_000)
+    val events = mutableListOf<Pair<String, Map<String, Any?>>>()
+    ScreeningTimer.resetForTesting(clock) { event, props -> events.add(event to props) }
+
+    val screeningId = ScreeningTimer.start(batteryStartPct = 80)
+    clock.now = 1_250
+    ScreeningTimer.markStep(screeningId, "questionnaire_loaded")
+    clock.now = 1_500
+    ScreeningTimer.incrementRetake(screeningId)
+    ScreeningTimer.incrementPhoto(screeningId)
+    clock.now = 2_000
+    ScreeningTimer.end(
+      screeningId,
+      outcome = "submitted",
+      extraProps = mapOf(PostHogAnalytics.Props.BATTERY_PCT to 78),
+    )
+
+    val step = events.first { it.first == PostHogAnalytics.Events.SCREENING_STEP_COMPLETED }.second
+    assertEquals(screeningId, step[PostHogAnalytics.Props.SCREENING_ID])
+    assertEquals("questionnaire_loaded", step[PostHogAnalytics.Props.STEP_NAME])
+    assertEquals(250L, step[PostHogAnalytics.Props.STEP_DURATION_MS])
+    assertEquals(250L, step[PostHogAnalytics.Props.CUMULATIVE_DURATION_MS])
+
+    val retake = events.first { it.first == PostHogAnalytics.Events.PHOTO_RETAKEN }.second
+    assertEquals(1, retake[PostHogAnalytics.Props.RETAKE_INDEX])
+
+    val completed = events.first { it.first == PostHogAnalytics.Events.SCREENING_COMPLETED }.second
+    assertEquals(1_000L, completed[PostHogAnalytics.Props.TOTAL_DURATION_MS])
+    assertEquals("submitted", completed[PostHogAnalytics.Props.OUTCOME])
+    assertEquals(1, completed[PostHogAnalytics.Props.PHOTO_COUNT])
+    assertEquals(1, completed[PostHogAnalytics.Props.RETAKE_COUNT])
+    assertEquals(-2, completed[PostHogAnalytics.Props.BATTERY_DELTA_PCT])
+    assertTrue(events.none { it.first == PostHogAnalytics.Events.SCREENING_ABANDONED })
+  }
+
+  private class FakeClock(var now: Long) : ScreeningTimer.Clock {
+    override fun nowMs(): Long = now
+  }
+}


### PR DESCRIPTION
Fixes two AI screening regressions (false-negative race condition, blank AI result image) and adds end-to-end PostHog instrumentation for
  the screening flow.

  - AI false-negative race condition fix — model load on the Main dispatcher was racing with the IO-thread forward pass, hitting a null
  Module, throwing, and surfacing as "Error" which the case-level combine read as Non-Suspicious. CameraxLauncherFragment now awaits
  initModelJob before running inference on Dispatchers.IO.
  - AI result page blank image fix — images shown on the AI result page were occasionally blank due to URI / cache lifecycle issues. Photos
  are now copied to the app cache and loaded from a stable path; AIResultActivity, QuestionnaireActivity, and QuestionnaireViewModel were
  reworked to use this path consistently.
  - Reverted per-photo AI result display — moved back to a single consolidated AI result view at the end of the screening rather than
  showing each photo's result inline.
  - PostHog screening analytics — added a full instrumentation surface around photo capture and inference (per-model + ensemble), image
  quality, device metrics, and screening timeline:
    - PostHogAnalytics / PostHogAnalyticsLogger — typed events and props (PHOTO_CAPTURED, MODEL_INFERENCE_COMPLETED, screening lifecycle).
    - ScreeningTimer — tracks per-step timings, retake count, photo count for a screeningId.
    - ImageQualityAnalyzer — emits image quality props (blur, brightness, etc.) alongside each capture, runs even when AI inference is
  disabled.
    - DeviceMetrics — snapshots device-side metrics per capture.
    - CameraxLauncherFragment refactored: runInference returns a richer ModelInferenceResult (probability, entropy, inference time,
  low-confidence flag) used purely for analytics; the preprocessing pipeline, sigmoid → 0.5 threshold, ensemble AND, and average-confidence
  logic are unchanged.
    - Added MODEL_VERSION = "v38" and LOW_CONFIDENCE_THRESHOLD = 65f constants (analytics flag only, not a decision gate).
  - Hilt analytics module — AnalyticsModule + AnalyticsLogger / AnalyticsLoggerEntryPoint to inject the analytics surface where needed.
  - Cleanup — removed debug snippets from camera and questionnaire flow.
  - Tests — added QuestionnaireViewModelAiSummaryTest, ImageQualityAnalyzerTest, ScreeningTimerTest; expanded QuestionnaireViewModelTest.

  Behavior changes worth flagging for review

  - When AI inference is disabled, processImage is now still invoked to compute image-quality props for analytics. This adds a scaleImageMat
   + ImageQualityAnalyzer.analyze pass on every capture in the AI-off path (previously a no-op).
  - CameraxLauncherFragment.newInstance now takes an optional screeningId; existing callers that don't pass it continue to work.
  - Image storage location for the result page moved to the app cache directory.

  Test plan

  - Capture a photo with AI enabled — verify no false-negative "Error → Non-Suspicious" path.
  - Capture a photo with AI disabled — verify it still saves, and that quality props are emitted to PostHog without blocking the UI.
  - Complete a screening — verify the AI result page renders the captured image (no blank).
  - Retake a photo and finish a screening — verify retakeCount, photoCount, and timeline steps appear correctly in PostHog.
  - Verify PHOTO_CAPTURED event carries screening_id, time_to_capture_ms, capture_to_result_ms, quality props, device metrics, and inference
   timings.
  - Verify a MODEL_INFERENCE_COMPLETED event fires per model (v6, v8, v82) and once for the ensemble pseudo-model.
  - Run the new unit tests: QuestionnaireViewModelAiSummaryTest, ImageQualityAnalyzerTest, ScreeningTimerTest, expanded
  QuestionnaireViewModelTest.
  - Confirm prediction/confidence values shown to the user are unchanged versus main for a known fixture image.
