### PR TITLE
Fix: point site config URL at the hosted multi-tenant config

### DIFF
--- a/android/engine/src/main/java/org/smartregister/fhircore/engine/domain/networkUtils/HttpConstants.kt
+++ b/android/engine/src/main/java/org/smartregister/fhircore/engine/domain/networkUtils/HttpConstants.kt
@@ -2,9 +2,7 @@ package org.smartregister.fhircore.engine.domain.networkUtils
 
 object HttpConstants {
     const val SOMETHING_WANT_WRONG  ="Oops, something went wrong. Our best minds are at work to bring it back to normal."
-    // Multi-tenant config (per multi-tenancy migration doc, §5.1). The old endpoint
-    // continues to serve the legacy `environments`/`sites` JSON to older app builds.
-    const val SELECT_YOUR_SITE_URL = "https://storage.googleapis.com/arogyam-app-config/config.json"
+    const val SELECT_YOUR_SITE_URL = "https://storage.googleapis.com/aa-common-app-bkt/aa-api/multi-tenant-sites.json"
     const val UPLOAD_IMAGE_URL = "http://hl7.org/fhir/StructureDefinition/file-location"
     const val HEADER_APPLICATION_JSON = "application/json"
 }


### PR DESCRIPTION
## Summary
- Repoints `HttpConstants.SELECT_YOUR_SITE_URL` to `https://storage.googleapis.com/aa-common-app-bkt/aa-api/multi-tenant-sites.json`, where the new multi-tenant config is hosted. The previous URL pointed at `gs://arogyam-app-config/config.json`, a bucket that does not exist.
- The new file lives alongside the legacy `sites.json` in the same bucket; older app builds continue to read the legacy file unchanged.

## Test plan
- [ ] Launch the app on a clean install — site picker loads without errors.
- [ ] Confirm the server list reflects the entries in `multi-tenant-sites.json` (14 sites).
- [ ] Pick a site, sign in, and confirm the FHIR/auth base URLs route to the expected backend.
- [ ] Verify legacy app builds (pre-multi-tenancy) still load `sites.json` from the same bucket.