### PR TITLE
AAR-281: Show 'Select Site' placeholder in site selection dropdown

### DIFF
--- a/android/engine/src/main/res/values/strings.xml
+++ b/android/engine/src/main/res/values/strings.xml
@@ -192,6 +192,7 @@
     <string name="data_migration_started">Started data migration from version %1$d</string>
     <string name="data_migration_completed">Application data migrated to version %1$d</string>
     <string name="select_your_site">Select your site</string>
+    <string name="select_site_placeholder">Select Site</string>
     <string name="btn_continue">CONTINUE</string>
     <string name="btn_back">BACK</string>
     <string name="iisc">IISc</string>

--- a/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/selectSite/SelectSiteScreen.kt
+++ b/android/quest/src/main/java/org/smartregister/fhircore/quest/ui/selectSite/SelectSiteScreen.kt
@@ -278,6 +278,9 @@ fun <T> SelectionDropdown(
                     value = selectedItem?.let(nameOf) ?: "",
                     onValueChange = {},
                     readOnly = true,
+                    placeholder = {
+                        Text(text = stringResource(id = R.string.select_site_placeholder))
+                    },
                     trailingIcon = {
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
                     },


### PR DESCRIPTION
The site selection dropdown rendered blank on initial load because the OutlinedTextField had no placeholder and showed an empty string when no item was selected. Add a placeholder so the field displays 'Select Site' until the user picks a tenant.

**IMPORTANT: Where possible all PRs must be linked to a Github issue**

Fixes [link to issue]

**Engineer Checklist**
- [ ] I have written **Unit tests** for any new feature(s) and edge cases for bug fixes
- [ ] I have added any strings visible on UI components to the `strings.xml` file
- [ ] I have updated the  [CHANGELOG.md](./CHANGELOG.md) file for any notable changes to the codebase
- [ ] I have run `./gradlew spotlessApply` and `./gradlew spotlessCheck` to check my code follows the project's style guide
- [ ] I have built and run the FHIRCore app to verify my change fixes the issue and/or does not break the app 
- [ ] I have checked that this PR does NOT introduce **breaking changes** that require an update to **_Content_** and/or **_Configs_**? _If it does add a sample here or a link to exactly what changes need to be made to the content._


**Code Reviewer Checklist**
- [ ] I have verified **Unit tests** have been written for any new feature(s) and edge cases
- [ ] I have verified any strings visible on UI components are in the `strings.xml` file
- [ ] I have verifed the [CHANGELOG.md](./CHANGELOG.md) file has any notable changes to the codebase
- [ ] I have verified the solution has been implemented in a configurable and generic way for reuseable components
- [ ] I have built and run the FHIRCore app to verify the change fixes the issue and/or does not break the app
 
